### PR TITLE
Lift metadata key `compatibility` from `istqb/sample-exam` to `common`

### DIFF
--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -49,6 +49,7 @@
     release .tl_gset:N = \g_istqb_release_tl,
     prefix .tl_gset:N = \g_istqb_prefix_tl,
     logo .tl_gset:N = \g_istqb_logo_tl,
+    compatibility .tl_gset:N = \g_istqb_compatibility_tl,
   }
 \tl_new:N \l_istqb_current_third_party_name_tl
 \tl_new:N \l_istqb_current_third_party_logo_tl

--- a/template/markdownthemeistqb_sample-exam.sty
+++ b/template/markdownthemeistqb_sample-exam.sty
@@ -13,13 +13,6 @@
     },
   }
 
-% Metadata
-\keys_define:nn
-  { istqb/metadata }
-  {
-    compatibility .tl_gset:N = \g_istqb_compatibility_tl,
-  }
-
 % Questions
 %% Global variables
 \int_new:N \g_istqb_duration_min_int


### PR DESCRIPTION
This pull request lifts the metadata key `compatibility` from the Markdown theme `istqb/sample-exam` to `istqb/common`.

This pull request continues ticket https://github.com/istqborg/istqb_shared_documents/issues/108.