### PR TITLE
Remove the header and footer from the landing page. The first page will be the one after the landing page.

### DIFF
--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -277,11 +277,13 @@
 \newcommand
   \istqblandingpage
   {
+    \thispagestyle
+      { empty }
     \group_begin:
     \parskip=0pt
     \centering
     \leavevmode
-    \par \vfill \vfill
+    \par
     \normalfont
     \bfseries
     \fontsize { 24 } { 28.8 } \selectfont
@@ -396,7 +398,7 @@
         \seq_use:Nn
           \l_tmpa_seq
           { \qquad }
-        \par \vfill
+        \par
       }
     \par
     \group_end:
@@ -529,6 +531,7 @@
 % Index
 \RequirePackage{imakeidx}
 \makeindex[columns=2, columnsep=1cm, noautomatic]
+\indexsetup{firstpagestyle=fancy}
 %% Ensure that the index is numbered and part of the table of contents.
 \renewcommand\imki@indexlevel{\section}
 %% Remove spaces between indexed items.

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -163,9 +163,19 @@
       \int_set:Nn
         \l_tmpa_int
         { \thepage - 1 }
-      \int_set:Nn
-        \l_tmpb_int
-        { \lastpage@lastpage - 1 }
+      \str_if_eq:VnTF
+        \lastpage@lastpage
+        { ?? }
+        {
+          \int_set:Nn
+            \l_tmpb_int
+            { 999 }
+        }
+        {
+          \int_set:Nn
+            \l_tmpb_int
+            { \lastpage@lastpage - 1 }
+        }
       \mbox
         {
           Page~

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -160,7 +160,21 @@
       \end{minipage}
       \begin{minipage}{0.2\linewidth}
       \centering
-      \mbox{Page~\thepage{}~of~\pageref{LastPage}}
+      \int_set:Nn
+        \l_tmpa_int
+        { \thepage - 1 }
+      \int_set:Nn
+        \l_tmpb_int
+        { \lastpage@lastpage - 1 }
+      \mbox
+        {
+          Page~
+          \int_use:N
+            \l_tmpa_int
+          {}~of~
+          \int_use:N
+            \l_tmpb_int
+        }
       \end{minipage}
       \begin{minipage}{0.4\linewidth}
       \hfill

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -92,6 +92,11 @@
           \g_istqb_schema_tl
           { ~ }
         \mbox { \g_istqb_level_tl }
+        \tl_if_empty:NF
+          \g_istqb_code_tl
+          {
+            \mbox { ~(\g_istqb_code_tl) }
+          }
       }
     \tl_if_empty:NF
       \g_istqb_title_tl
@@ -105,11 +110,6 @@
           }
           { \\ }
         \g_istqb_title_tl
-        \tl_if_empty:NF
-          \g_istqb_code_tl
-          {
-            \mbox { ~(\g_istqb_code_tl) }
-          }
       }
   \end{minipage}
 }


### PR DESCRIPTION
This PR closes the first two TODOs from https://github.com/istqborg/istqb_product_base/issues/10:

> TODOs:
> 1. Remove the header and footer from the landing page. The first page will be the one after the landing page.
> 2. Add a `code` from metadata in the first line of the header so it will be: ISTQB® Certified Tester Foundation Level (CTFL)

Here is how the example document looks after this PR:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/68fafed3-80f4-4b98-a8fa-2c9da91a63f6)

For ease of review, I highlighted the affected parts of the example document.