### PR TITLE
Add support for e-mail links like `[translation@castb.org](mailto:translation@castb.org)`

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,7 +18,7 @@ jobs:
     name: Validate YAML documents
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
+      image: witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         shell: bash
@@ -57,7 +57,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
+      image: witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         run: |
@@ -99,7 +99,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
+      image: witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         run: |
@@ -141,7 +141,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
+      image: witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,7 +18,7 @@ jobs:
     name: Validate YAML documents
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.2.0-43-gc109d22b-latest
+      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         shell: bash
@@ -57,7 +57,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.2.0-43-gc109d22b-latest
+      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         run: |
@@ -99,7 +99,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.2.0-0-g034c66fb-latest
+      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         run: |
@@ -141,7 +141,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.2.0-0-g034c66fb-latest
+      image: ghcr.io/witiko/markdown:3.4.2-39-g415379f9-latest
     steps:
       - name: Install required packages
         run: |


### PR DESCRIPTION
This PR closes TODO 6 from https://github.com/istqborg/istqb_product_base/issues/10:

> TODOs: [...]
>
> 6. add support for email links like `[translation@castb.org](mailto:translation@castb.org)`. Currently, it's generating the following
![image](https://github.com/istqborg/istqb_product_base/assets/95688217/beb5d4f0-3452-4c34-a58c-96ecc44b5e86)

After this PR, `[translation@castb.org](mailto:translation@castb.org)` and `<translation@castb.org>` produce this output:
![image](https://github.com/istqborg/istqb_product_base/assets/603082/6b424fb2-c861-41ad-939d-7baecdea39a4)