### PR TITLE
Support unnumbered subsections

### DIFF
--- a/example-document/00-introduction.md
+++ b/example-document/00-introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-## Purpose of this Syllabus
+## Purpose of this Syllabus {-}
 This syllabus outlines the scope of the \<module-name\> certification.
 
 Together with the \<module-code\> body of knowledge the syllabus forms the basis for the International Software Testing Qualification for \<module-name\> at the Advanced Level. The ISTQB® provides this syllabus as follows:

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -201,8 +201,10 @@
                   { ##1 }
                   { unnumbered }
                   {
+                    \group_begin:
                     \markdownSetup
                       {
+                        %% Stop numbering all levels of sections.
                         rendererPrototypes = {
                           headingOne = {
                             \istqbunnumberedsection { ####1 }
@@ -212,6 +214,14 @@
                           },
                           headingThree = {
                             \istqbunnumberedsubsubsection { ####1 }
+                          },
+                          %% Count the number of nested sections, so that we only start numbering
+                          %% sections again when the top-level unnumbered section has ended.
+                          sectionBegin = {
+                            \group_begin:
+                          },
+                          sectionEnd = {
+                            \group_end:
                           },
                         }
                       }


### PR DESCRIPTION
Closes https://github.com/istqborg/istqb_ctal-ta/issues/2.

For example, here is a markdown document that includes an unnumbered subsection:

https://github.com/istqborg/istqb_product_base/blob/3d26cf9ab8b8928897d06d578a6d7e53ef4ad319/example-document/00-introduction.md?plain=1#L1-L21

Here is the output produced by the template:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/4e84abc5-1d5b-4483-acf5-879c7d728ebc)

@AdamRomanPL: The section is still in the same format (framed box) and still in table of contents, just without the numbering:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/7106b2cf-eaf6-4b28-a9a1-553006d2b59d)