### PR TITLE
Do not split questions over more pages

### DIFF
--- a/template/markdownthemeistqb_sample-exam_questions.sty
+++ b/template/markdownthemeistqb_sample-exam_questions.sty
@@ -40,6 +40,7 @@
         \seq_map_inline:Nn
           \g_istqb_questions_seq
           {
+            \vbox \bgroup  % Put each question in a vbox to prevent page breaks.
             \group_begin:
             % Print question heading.
             \tl_set:Nn
@@ -139,6 +140,7 @@
               \l_tmpa_int = { 1 }
               { s }.
             \group_end:
+            \egroup
           }
       },
     },


### PR DESCRIPTION
This PR fixes point 9 from ticket #10:

> - [ ] do not split questions over more pages

Here is how the Sample Exam Questions document looks after this PR:

![image](https://github.com/istqborg/istqb_product_template/assets/603082/e940e9f7-d051-40a9-9a15-ee0136fc700e)

See also https://github.com/istqborg/istqb_product_template/pull/9.