### PR TITLE
Add support for localized product documents in Czech and Slovak

### DIFF
--- a/example-document/03-markdown-guidelines.md
+++ b/example-document/03-markdown-guidelines.md
@@ -13,6 +13,7 @@ version: Version v0.1
 date: 31 October 2023
 release: For internal use only
 logo: istqb-logo-default
+language: en
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -8,6 +8,7 @@ version: Version v0.1
 date: 31 October 2023
 release: For internal use only
 logo: istqb-logo-default
+language: en
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules

--- a/schema/metadata.yml
+++ b/schema/metadata.yml
@@ -9,6 +9,7 @@ date: str(required=False)
 release: str(required=False)
 prefix: str(required=False)
 compatibility: str(required=False)
+language: str(required=False)
 provided-by: include('third-parties', required=False)
 ---
 third-parties: list(any(str(), include('third-party')))

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -53,6 +53,38 @@
 \usepackage{parskip}  % Put half of line height between paragraphs.
 \sloppy  % Prevent overfull lines.
 
+%% Language
+\RequirePackage[czech,slovak,english]{babel}
+\ExplSyntaxOn
+\tl_new:N \g_istqb_language_tl
+\cs_new:Nn
+  \istqb_set_language:n
+  {
+    \tl_gset:Nn
+      \g_istqb_language_tl
+      { #1 }
+    \str_case:nnF
+      { #1 }
+      {
+        { cs } { \selectlanguage { czech } }
+        { sk } { \selectlanguage { slovak } }
+        { en } { \selectlanguage { english } }
+      }
+      {
+        \msg_error:nnn
+          { istqb }
+          { unknown-language }
+          { #1 }
+      }
+  }
+\msg_new:nnn
+  { istqb }
+  { unknown-language }
+  { Unknown language "#1" }
+\istqb_set_language:n
+  { en }
+\ExplSyntaxOff
+
 %% Typefaces
 \RequirePackage[T1]{fontenc}
 \RequirePackage{tgheros}

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -66,9 +66,18 @@
     \str_case:nnF
       { #1 }
       {
-        { cs } { \selectlanguage { czech } }
-        { sk } { \selectlanguage { slovak } }
-        { en } { \selectlanguage { english } }
+        { cs } {
+          \selectlanguage { czech }
+          \def \istqbfurtherreadingname { Další~zdroje }
+        }
+        { sk } {
+          \selectlanguage { slovak }
+          \def \istqbfurtherreadingname { Ďalšie~zdroje }
+        }
+        { en } {
+          \selectlanguage { english }
+          \def \istqbfurtherreadingname { Further~Reading }
+        }
       }
       {
         \msg_error:nnn
@@ -304,7 +313,7 @@
 %% Reference printing
 \newcommand\printistqbbibliography{%
   \clearpage
-  \section{References}%
+  \section{\refname}%
   \label{references}%
   \begingroup
   \defbibheading{bibliography}{%
@@ -320,7 +329,7 @@
   \endgroup
   \begingroup
   \defbibheading{bibliography}{\section{##1}\label{further-reading}}%
-  \printbibliography[filter=further-reading, title=Further Reading]%
+  \printbibliography[filter=further-reading, title=\istqbfurtherreadingname]%
   \endgroup
 }
 

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -57,6 +57,7 @@
     prefix .tl_gset:N = \g_istqb_prefix_tl,
     logo .tl_gset:N = \g_istqb_logo_tl,
     compatibility .tl_gset:N = \g_istqb_compatibility_tl,
+    language .code:n = { \istqb_set_language:n { #1 } },
   }
 \tl_new:N \l_istqb_current_third_party_name_tl
 \tl_new:N \l_istqb_current_third_party_logo_tl


### PR DESCRIPTION
This PR will fix point 8 from https://github.com/istqborg/istqb_product_base/issues/10:

> - [ ] add support for Contents, References, Further Reading, List of Tables, List of Images, Index, Section references in text in languages other than English (Czech and Slovak for now)