### PR TITLE
Prevent page breaks in table of contents and around section headings

### DIFF
--- a/example-document/03-markdown-guidelines.md
+++ b/example-document/03-markdown-guidelines.md
@@ -286,7 +286,7 @@ Here is a short paragraph with \emph{emphasized} and \textbf{bold} text.
 Here is a long paragraph:
 \medskip
 
-\lipsum[1]
+\lipsum[2]
 
 &
 
@@ -369,7 +369,7 @@ Here is a short paragraph with \emph{emphasized} and \textbf{bold} text.
 Here is a long paragraph:
 \medskip
 
-\lipsum[1]
+\lipsum[2]
 
 &
 

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -440,6 +440,38 @@
 \ExplSyntaxOff
 
 % Headings
+\ExplSyntaxOn
+\int_new:N
+  \g_istqb_previous_heading_level
+\int_gset:Nn
+  \g_istqb_previous_heading_level
+  { 0 }
+\cs_new:Npn
+  \istqbupdateheadinglevel
+  #1
+  {
+    \int_if_zero:VF
+      \g_istqb_previous_heading_level
+      {
+        % Encourage page breaks before sections
+        \penalty -2000
+        % Discourage page breaks between sections and subsections in TOC
+        \int_compare:nT
+          { \g_istqb_previous_heading_level < #1 }
+          { \addtocontents { toc } { \nopagebreak } }
+        % Encourage page breaks between subsections and sections in TOC
+        \int_compare:nT
+          { \g_istqb_previous_heading_level > #1 }
+          { \addtocontents { toc } { \pagebreak[0] } }
+      }
+    \int_gset:Nn
+      \g_istqb_previous_heading_level
+      { #1 }
+  }
+\cs_generate_variant:Nn
+  \int_if_zero:nF
+  { VF }
+\ExplSyntaxOff
 %% Sections, subsections, and subsubsections
 \RequirePackage{xpatch, mdframed}
 \xpatchcmd{\section}{\normalfont\Large\bfseries}{\istqbsectionbox}{}{\PatchFailed}
@@ -500,16 +532,32 @@
 \titlespacing\section{0pt}{0pt}{*3.2}
 \titlespacing\subsection{0pt}{*5.5}{*0.8}
 \titlespacing\subsubsection{0pt}{*3.25}{*1}
+%%% Document commands
+\newcommand\istqbsection[1]{%
+  \istqbupdateheadinglevel{1}%
+  \section{#1}%
+}
+\newcommand\istqbsubsection[1]{%
+  \istqbupdateheadinglevel{2}%
+  \subsection{#1}%
+}
+\newcommand\istqbsubsubsection[1]{%
+  \istqbupdateheadinglevel{3}%
+  \subsubsection{#1}%
+}
 \newcommand\istqbunnumberedsection[1]{%
+  \istqbupdateheadinglevel{1}%
   \section*{#1}%
   \markboth{#1}{#1}%
   \addcontentsline{toc}{section}{#1}%
 }
 \newcommand\istqbunnumberedsubsection[1]{%
+  \istqbupdateheadinglevel{2}%
   \subsection*{#1}%
   \addcontentsline{toc}{subsection}{#1}%
 }
 \newcommand\istqbunnumberedsubsubsection[1]{%
+  \istqbupdateheadinglevel{3}%
   \subsubsection*{#1}%
   \addcontentsline{toc}{subsubsection}{#1}%
 }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -362,6 +362,15 @@
   {
     headerAttributes,
     rendererPrototypes = {
+      headingOne = {
+        \istqbsection { #1 }
+      },
+      headingTwo = {
+        \istqbsubsection { #1 }
+      },
+      headingThree = {
+        \istqbsubsubsection { #1 }
+      },
       headingFour = {
         \paragraph { #1 }
         \leavevmode


### PR DESCRIPTION
This PR prevents page breaks in table of contents (TOC) and around section headings using the following approaches:

- Encourage page breaks before sections, so sections that start at page bottom are more likely to be postponed to next page.
- Discourage page breaks between sections and subsections in TOC.
- Encourage page breaks between subsections and sections in TOC.

Below are before-and-after examples for the changes from this PR:

### Table of contents
#### Before this PR
![Screenshot from 2024-04-23 11-38-09](https://github.com/istqborg/istqb_product_base/assets/603082/2d52bfab-ffa9-473c-984b-ec075291c283)
#### After this PR
![Screenshot from 2024-04-23 11-38-42](https://github.com/istqborg/istqb_product_base/assets/603082/6fa137f7-2bbb-47d6-884d-9a14f50a1d67)
### Section headings
#### Before this PR
![Screenshot from 2024-04-23 11-54-15](https://github.com/istqborg/istqb_product_base/assets/603082/66d2d7a8-cece-4bfb-8578-184402ac246e)
#### After this PR
![Screenshot from 2024-04-23 11-54-34](https://github.com/istqborg/istqb_product_base/assets/603082/70e6560e-6272-4c70-8572-c2d0a2ed23c1)

This PR closes #24.