### PR TITLE
Update the Markdown package to version 3.5.0 (2024-04-29)

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -18,7 +18,7 @@ jobs:
     name: Validate YAML documents
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.4.3-0-ge2c6be1a-latest
+      image: witiko/markdown:3.5.0-0-gfd01a252-latest
     steps:
       - name: Install required packages
         shell: bash
@@ -67,7 +67,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.4.3-0-ge2c6be1a-latest
+      image: witiko/markdown:3.5.0-0-gfd01a252-latest
     steps:
       - name: Install required packages
         run: |
@@ -110,7 +110,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.4.3-0-ge2c6be1a-latest
+      image: witiko/markdown:3.5.0-0-gfd01a252-latest
     steps:
       - name: Install required packages
         run: |
@@ -153,7 +153,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.4.3-0-ge2c6be1a-latest
+      image: witiko/markdown:3.5.0-0-gfd01a252-latest
     steps:
       - name: Install required packages
         run: |

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -134,7 +134,10 @@
 \renewcommand{\footrulewidth}{0pt}
 \RequirePackage{xcolor}
 \RequirePackage{mdframed}
-\RequirePackage{lastpage}
+\@ifundefined
+  {HCode}%
+  {\RequirePackage{lastpage}}%
+  {\def\lastpage@lastpage{??}}
 \ExplSyntaxOn
 \tl_new:N \g_istqb_version_tl
 \tl_new:N \g_istqb_date_tl

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -410,6 +410,8 @@
                         }
                       }
                   }
+              },
+              attributeClassName += {
                 %% Landscape sections
                 \tl_if_eq:nnT
                   { ##1 }
@@ -436,6 +438,8 @@
                         }
                       }
                   }
+              },
+              attributeClassName += {
                 %% Revision history
                 \tl_if_eq:nnT
                   { ##1 }
@@ -486,6 +490,8 @@
                         }
                       }
                   }
+              },
+              attributeClassName += {
                 %% Learning objectives
                 \tl_if_eq:nnT
                   { ##1 }


### PR DESCRIPTION
This PR updates the Markdown package to version 3.5.0 (2024-04-29).