### PR TITLE
During validation, check that `logo` metadata values do not contain `_` and validate also files named `metadata*.yml`, not just `metadata.yml`

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -43,12 +43,12 @@ jobs:
           cd istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
           parallel --halt now,fail=1 'sed -i "1s/^/$(sed -rn "/^name\.babel = /s/name\.babel = /babel-language: /p" "$(kpsewhich {/.}/babel-{/.}.ini)")\n/" {}' ::: languages/*.yml
-      - name: Validate metadata.yml
+      - name: Validate metadata*.yml
         shell: bash
         run: |
           set -ex
           source ~/venv/bin/activate
-          $FIND -type f -iregex '.*/metadata\.yml$' -print | parallel --halt now,fail=1 yamale --schema=istqb_product_base/schema/metadata.yml {}
+          $FIND -type f -iregex '.*/metadata.*\.yml$' -print | parallel --halt now,fail=1 yamale --schema=istqb_product_base/schema/metadata.yml {}
       - name: Validate questions.yml
         shell: bash
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -43,11 +43,6 @@ jobs:
           cd istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
           parallel --halt now,fail=1 'sed -i "1s/^/$(sed -rn "/^name\.babel = /s/name\.babel = /babel-language: /p" "$(kpsewhich {/.}/babel-{/.}.ini)")\n/" {}' ::: languages/*.yml
-      - name: Check the well-formedness of all YAML documents
-        run: |
-          set -ex
-          $FIND -type f -iregex '.*\.yml$' -print | parallel --halt now,fail=1 istqb_product_base/check-yaml.lua {}
-          parallel --halt now,fail=1 istqb_product_base/check-yaml.lua {} ::: istqb_product_base/languages/*.yml
       - name: Validate metadata.yml
         shell: bash
         run: |
@@ -66,6 +61,11 @@ jobs:
           set -ex
           source ~/venv/bin/activate
           parallel --halt now,fail=1 yamale --schema=istqb_product_base/schema/language.yml {} ::: istqb_product_base/languages/*.yml
+      - name: Check the well-formedness of all YAML documents
+        run: |
+          set -ex
+          $FIND -type f -iregex '.*\.yml$' -print | parallel --halt now,fail=1 istqb_product_base/check-yaml.lua {}
+          parallel --halt now,fail=1 istqb_product_base/check-yaml.lua {} ::: istqb_product_base/languages/*.yml
   produce-pdf:
     name: Produce PDF documents
     needs:

--- a/check-yaml.lua
+++ b/check-yaml.lua
@@ -6,7 +6,9 @@ kpse.set_program_name("luatex")
 local tinyyaml = require("markdown-tinyyaml")
 local file, input, output, ran_ok, err
 local some_failed = false
+local this_failed
 for _, filename in ipairs(arg) do
+  this_failed = false
   file = assert(io.open(arg[1], "r"))
   input = assert(file:read("*a"))
   ran_ok, err = pcall(function()
@@ -14,9 +16,28 @@ for _, filename in ipairs(arg) do
   end)
   if not ran_ok then
     print("File " .. filename .. " is not well-formed: " .. err)
-    some_failed = true
+    this_failed = true
   elseif not output then
     print("File " .. filename .. " contained no data.")
+    this_failed = true
+  else
+    if output.logo ~= nil and string.find(output.logo, "_") then
+      print("\nFile " .. filename .. " contains `logo: " .. output.logo .. "`, which contains underscores (`_`).")
+      print("Underscores cause issues, see <https://github.com/istqborg/istqb_product_base/issues/46>. Please, remove them.\n")
+      this_failed = true
+    end
+    if output['provided-by'] ~= nil then
+      for i, provided_by in ipairs(output['provided-by']) do
+        if provided_by.logo ~= nil and string.find(provided_by.logo, "_") then
+          print("\nFile " .. filename .. " contains `provided_by[" .. i .. "].logo: " .. provided_by.logo .. "`, which contains underscores (`_`).")
+          print("Underscores cause issues, see <https://github.com/istqborg/istqb_product_base/issues/46>. Please, remove them.\n")
+          this_failed = true
+        end
+      end
+    else
+    end
+  end
+  if this_failed then
     some_failed = true
   else
     print("File " .. filename .. " is well-formed.")


### PR DESCRIPTION
This PR closes the following item from ticket https://github.com/istqborg/istqb_product_base/issues/46#issue-2275450316:

> - [x] During YAML validation in the CI, print a human-readable error when `logo` metadata values contain `_`.

Furthermore, this PR also changes the CI, so that it validates files named `metadata*.yml`, not just `metadata.yml`, as discussed in [istqborg/istqb-ctfl\#14 (comment)](https://github.com/istqborg/istqb-ctfl/pull/14/files#r1587590925).