### PR TITLE
In Sample Exam Questions documents, indent multiline answers

### DIFF
--- a/template/markdownthemeistqb_sample-exam_questions.sty
+++ b/template/markdownthemeistqb_sample-exam_questions.sty
@@ -96,12 +96,12 @@
               \l_tmpa_clist
             \medskip
             \setdefaultleftmargin
-              { 0pt }
-              { 0pt }
-              { 0pt }
-              { 0pt }
-              { 0pt }
-              { 0pt }
+              { 1.5em }
+              { }
+              { }
+              { }
+              { }
+              { }
             \begin { enumerate }
             \clist_map_inline:Nn
               \l_tmpa_clist


### PR DESCRIPTION
This PR adds indentation to second-to-last lines of multiline answers in Sample Exam Questions documents:

![Screenshot from 2024-05-07 12-32-11](https://github.com/istqborg/istqb_product_base/assets/603082/a324cd2b-d6df-4191-a921-f866b0ce01b3)

Closes #28.