### PR TITLE
Fix issues with the Czech and Slovak localization

### DIFF
--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -207,9 +207,11 @@ This will produce the same output as the heading of this section.
 
 You can reference the section from the text of the document by writing `<#section:section-references>`. This will produce the following output: <#section:section-references>.
 
-If you are writing a document in a flective language other than English such as Czech, writing `<#section:section-references>` will produce a text in accusative case such as [Sekci `\ref{section:section-references}`{=tex}](#section:section-references). You can explictly use a different grammatical case such as the nominative by writing  ``[Sekce `\ref{section:section-references}`{=tex}](#section:section-references)``. This will produce the following output: [Sekce `\ref{section:section-references}`{=tex}](#section:section-references).
+You can produce just a section number by writing `<#section:section-references>{-}`. This will produce the following output: <#section:section-references>{-}.
 
 You can also create a clickable link to the section by writing `[displayed text](#section:section-references)`. This will produce the following output: [displayed text](#section:section-references).
+
+If you are writing a document in a flective language other than English such as Czech, writing `<#section:section-references>` will produce a text in accusative case such as [kapitolu <#section:section-references>{-}](#section:section-references). You can combine the above techniques and explictly use a different grammatical case such as the nominative "kapitola" by writing `[kapitola <#section:section-references>{-}](#section:section-references)`. This will produce the following output: [kapitola <#section:section-references>{-}](#section:section-references).
 
 ## Figures {#figures}
 

--- a/languages/cs.yml
+++ b/languages/cs.yml
@@ -14,3 +14,4 @@ page: [Strana, z]
 provided-by: [Poskytl, Poskytli]
 istqb: International Software Testing Qualifications Board
 list-delimiters: [a, ',', a]
+contents: Obsah

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -14,3 +14,4 @@ page: [Page, out of]
 provided-by: [Provided by, Provided by]
 istqb: International Software Testing Qualifications Board
 list-delimiters: [and, ',', ', and']
+contents: Contents

--- a/languages/sk.yml
+++ b/languages/sk.yml
@@ -14,3 +14,4 @@ page: [Strana, z]
 provided-by: [Poskytol, Poskytli]
 istqb: International Software Testing Qualifications Board
 list-delimiters: [a, ',', a]
+contents: Obsah

--- a/schema/language.yml
+++ b/schema/language.yml
@@ -15,3 +15,4 @@ page: [str(), str()]
 provided-by: [str(), str()]
 istqb: str()
 list-delimiters: [str(), str(), str()]
+contents: str()

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -101,6 +101,7 @@
     references .tl_gset:N = \istqbrefname,
     further-reading .tl_gset:N = \istqbfurtherreadingname,
     istqb .tl_gset:N = \istqborgname,
+    contents .tl_gset:N = \contentsname,
   }
 \keys_define:nn
   { istqb / language / bibliography-subsections }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -744,7 +744,7 @@
                 \l_tmpb_tl
             ]
           }
-        \emph
+        \textit
           {
             \exp_last_unbraced:NV
               \hyperref
@@ -752,8 +752,37 @@
               { #1 }
           }
       }{
-        \emph { \href { #3 } { #1 } }
+        \textit { \href { #3 } { #1 } }
       }
+  }
+\bool_new:N \l_istqb_reference_short_bool
+\markdownSetup
+  {
+    linkAttributes,
+    rendererPrototypes = {
+      linkAttributeContextBegin = {
+        \group_begin:
+        \bool_set_false:N
+          \l_istqb_reference_short_bool
+        \markdownSetup
+          {
+            renderers = {
+              attributeClassName = {
+                \tl_if_eq:nnT
+                  { ##1 }
+                  { unnumbered }
+                  {
+                    \bool_set_true:N
+                      \l_istqb_reference_short_bool
+                  }
+              },
+            },
+          }
+      },
+      linkAttributeContextEnd = {
+        \group_end:
+      },
+    },
   }
 \tl_new:N \l_istqb_reference_label_tl
 \tl_new:N \l_istqb_reference_number_tl
@@ -813,24 +842,31 @@
             \exp_not:N \ref
               { \l_tmpa_tl }
           }
-        \tl_set:Nx
-          \l_tmpb_tl
+        \bool_if:NTF
+          \l_istqb_reference_short_bool
           {
-            \exp_not:N \emph
+            \textit { \tl_use:N \l_istqb_reference_number_tl }
+          }
+          {
+            \tl_set:Nx
+              \l_tmpb_tl
               {
-                \exp_not:N \hyperref
-                  [ \l_tmpa_tl ]
+                \exp_not:N \textit
                   {
-                    \l_istqb_reference_label_tl
-                    {}~
-                    \l_istqb_reference_number_tl
+                    \exp_not:N \hyperref
+                      [ \l_tmpa_tl ]
+                      {
+                        \l_istqb_reference_label_tl
+                        {}~
+                        \l_istqb_reference_number_tl
+                      }
                   }
               }
+            \tl_use:N
+              \l_tmpb_tl
           }
-        \tl_use:N
-          \l_tmpb_tl
       }{
-        \emph { \url { #2 } }
+        \textit { \url { #2 } }
       }
 }
 \cs_generate_variant:Nn


### PR DESCRIPTION
This PR fixes the following issues from ticket #51:

> 1. `Contents` should be translated as `Obsah` (applies for all language versions)
> 2. From the description in https://github.com/istqborg/istqb_product_base/issues/10#issuecomment-2049406254 I a[m] not sure how I can update section reference to support [other grammatical cases](https://github.com/istqborg/istqb-ctfl/blob/main/syllabus-sk/00-introduction.md?plain=1#L63)
> > Ad 2) A shorter version like `[kapitole <#section:references>{-}](#section:references)` would be nice. Also rename Sekcia to kapitola

Here is a demonstration of how issue 2 has been fixed from the example document:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/762a0034-21b5-4bdb-b2b7-b375cdc3554d)