### PR TITLE
Rename PDF documents based on metadata

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Convert XLSX spreadsheets to PDF
         run: $FIND -type f -iregex '.*\.xlsx$' -print | parallel --halt now,fail=1 libreoffice7.3 --headless --convert-to pdf {} --outdir {//}
       - name: Compile LaTeX documents to PDF
-        run: $FIND -type f -iregex '.*\.tex$'  -print | parallel --halt now,fail=1 test -e {//}/NO_PDF '||' latexmk -r istqb_product_base/latexmkrc {} '&&' 'mv -v {.}.pdf "$(cat {.}.istqb_project_name).pdf"'
+        run: $FIND -type f -iregex '.*\.tex$'  -print | parallel --halt now,fail=1 test -e {//}/NO_PDF '||' latexmk -r istqb_product_base/latexmkrc {} '&&' '(test {} = ./example-document.tex || mv -v {.}.pdf "$(cat {.}.istqb_project_name).pdf")'
       - name: Upload PDF documents
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -23,7 +23,7 @@ jobs:
     name: Validate YAML documents
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.5.0-21-gb542eccb-latest
+      image: witiko/markdown:3.6.0-10-g11b016ea-latest
     steps:
       - name: Install required packages
         shell: bash
@@ -72,7 +72,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.5.0-21-gb542eccb-latest
+      image: witiko/markdown:3.6.0-10-g11b016ea-latest
     steps:
       - name: Install required packages
         run: |
@@ -115,7 +115,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.5.0-21-gb542eccb-latest
+      image: witiko/markdown:3.6.0-10-g11b016ea-latest
     steps:
       - name: Install required packages
         run: |
@@ -158,7 +158,7 @@ jobs:
       - validate
     runs-on: ubuntu-latest
     container:
-      image: witiko/markdown:3.5.0-21-gb542eccb-latest
+      image: witiko/markdown:3.6.0-10-g11b016ea-latest
     steps:
       - name: Install required packages
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Convert XLSX spreadsheets to PDF
         run: $FIND -type f -iregex '.*\.xlsx$' -print | parallel --halt now,fail=1 libreoffice7.3 --headless --convert-to pdf {} --outdir {//}
       - name: Compile LaTeX documents to PDF
-        run: $FIND -type f -iregex '.*\.tex$'  -print | parallel --halt now,fail=1 test -e {//}/NO_PDF '||' latexmk -r istqb_product_base/latexmkrc {}
+        run: $FIND -type f -iregex '.*\.tex$'  -print | parallel --halt now,fail=1 test -e {//}/NO_PDF '||' latexmk -r istqb_product_base/latexmkrc {} '&&' 'mv -v {.}.pdf "$(cat {.}.istqb_project_name).pdf"'
       - name: Upload PDF documents
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Convert MD documents to DOCX
         run: $FIND -type f -iregex '.*\.md$' -print | parallel --halt now,fail=1 mkdir -p docx/{//} '&&' pandoc -f "${PANDOC_EXTENSIONS}" -i {} -o docx/{}.docx
       - name: Convert YAML documents to DOCX
-        run: $FIND -path ./.github -prune -o -type f -iregex '.*\.yml$' -print | parallel --halt now,fail=1 mkdir -p docx/{//} '&&' 'sed -e "1s/^/\`\`\` yml\\n/" -e "\$s/\$/\\n\`\`\`/"' {} '|' pandoc -f "${PANDOC_EXTENSIONS}+hard_line_breaks" -i - -o docx/{}.docx
+        run: $FIND -path ./.github -prune -o -path ./languages -prune -o -type f -iregex '.*\.yml$' -print | parallel --halt now,fail=1 mkdir -p docx/{//} '&&' 'sed -e "1s/^/\`\`\` yml\\n/" -e "\$s/\$/\\n\`\`\`/"' {} '|' pandoc -f "${PANDOC_EXTENSIONS}+hard_line_breaks" -i - -o docx/{}.docx
       - name: Convert BIB documents to DOCX
         run: $FIND -type f -iregex '.*\.bib$' -print | parallel --halt now,fail=1 mkdir -p docx/{//} '&&' 'sed -e "1s/^/\`\`\` bib\\n/" -e "\$s/\$/\\n\`\`\`/"' {} '|' pandoc -f "${PANDOC_EXTENSIONS}+hard_line_breaks" -i - -o docx/{}.docx
       - name: Upload DOCX documents

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -222,6 +222,7 @@
   }
 \tl_new:N \l_istqb_current_third_party_name_tl
 \tl_new:N \l_istqb_current_third_party_logo_tl
+\iow_new:N \g_istqb_project_name_iow
 \markdownSetupSnippet
   { metadata }
   {
@@ -297,12 +298,26 @@
       jekyllDataEnd = {
         \istqb_load_language:V
           \g_istqb_language_tl
+        \iow_open:Ne
+          \g_istqb_project_name_iow
+          { \c_sys_jobname_str .istqb_project_name }
+        \iow_now:Ne
+          \g_istqb_project_name_iow
+          { ISTQB- \g_istqb_code_tl - \g_istqb_type_tl - \g_istqb_version_tl }
+        \iow_close:N
+          \g_istqb_project_name_iow
       },
     },
   }
 \cs_generate_variant:Nn
   \istqb_load_language:n
   { V }
+\cs_generate_variant:Nn
+  \iow_open:Nn
+  { Ne }
+\cs_generate_variant:Nn
+  \iow_now:Nn
+  { Ne }
 
 % Images
 \markdownSetup


### PR DESCRIPTION
This PR renames the PDF documents produced by the CI based on metadata, as discussed in #52. For example, the example document from this repository would be named `ISTQB-CT-EXMPL-Syllabus-v0.1.pdf`. However, since the example document is linked from the `README.md` document of the repository [`istqborg/istqb_product_template`][1] and all repositories forked from it, I excluded the example document from the renaming in commit 59355b0 so that we don't need to change them all.

 [1]: https://github.com/istqborg/istqb_product_template

Furthermore, this PR also updated the Markdown package to v3.6.0 and excludes the YAML documents from the directory `languages/` in this repository from being included in the archive `DOCX.zip` produced by the CI.