### PR TITLE
Fix localized strings used in bibliographic references

### DIFF
--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -96,6 +96,8 @@
       \babelprovide
         [ import, main ]
         { #1 }
+      \selectlanguage
+        { #1 }
     },
     appendix .tl_gset:N = \istqbappendixname,
     references .tl_gset:N = \istqbrefname,


### PR DESCRIPTION
This PR fixes the formatting of bibliographic references:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/4b4b7615-9296-49b4-8c82-7c8bb81f4c42)
![image](https://github.com/istqborg/istqb_product_base/assets/603082/4791a2f6-ea45-4d58-b07c-b3811d67880f)

See also the discussion in https://github.com/istqborg/istqb_product_base/issues/55#issuecomment-2145890305.