### PR TITLE
Update header to match ISTQB template 4.0

### DIFF
--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -7,6 +7,7 @@ This chapter explains how to use the template for ISTQB® documents, but explani
 Data for the Landing page are defined in the file `metadata.yml` as follows:
 
 ```yaml
+organization: ISTQB®
 schema: Certified Tester
 level: Foundation Level
 title: Example Document

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -1,3 +1,4 @@
+organization: ISTQB®
 schema: Certified Tester
 level: Foundation Level
 title: Example Document

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -6,7 +6,7 @@ prefix: EXMPL
 code: CT-EXMPL
 type: Syllabus
 version: v0.1
-date: 2024/01/01
+date: 2024/06/04
 release: For internal use only
 logo: istqb-logo-default
 language: en

--- a/schema/metadata.yml
+++ b/schema/metadata.yml
@@ -1,3 +1,4 @@
+organization: str(required=False)
 schema: str(required=False)
 level: str(required=False)
 logo: str(required=False)

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -73,6 +73,7 @@
 \tl_new:N \g_istqb_title_tl
 \tl_new:N \g_istqb_code_tl
 \tl_new:N \g_istqb_logo_tl
+\tl_new:N \g_istqb_organization_tl
 \tl_gset:Nn
   \g_istqb_logo_tl
   { istqb-logo-default }

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -82,36 +82,62 @@
   \fontsize{9}{10.8}\selectfont
   \begin{minipage}[b]{0.7\linewidth}
     \tl_if_empty:NF
-      \g_istqb_schema_tl
+      \g_istqb_organization_tl
       {
-        \mbox { \g_istqb_schema_tl }
-      }
-    \tl_if_empty:NF
-      \g_istqb_level_tl
-      {
+        \mbox { \g_istqb_organization_tl }
         \tl_if_empty:NF
           \g_istqb_schema_tl
           { ~ }
+      }
+    \tl_if_empty:NF
+      \g_istqb_schema_tl
+      { \mbox { \g_istqb_schema_tl } }
+    \bool_if:nF
+      {
+        \tl_if_empty_p:N
+          \g_istqb_organization_tl &&
+        \tl_if_empty_p:N
+          \g_istqb_schema_tl
+      }
+      { \\ }
+    \tl_if_empty:NF
+      \g_istqb_level_tl
+      {
         \mbox { \g_istqb_level_tl }
         \tl_if_empty:NF
-          \g_istqb_code_tl
-          {
-            \mbox { ~(\g_istqb_code_tl) }
-          }
+          \g_istqb_type_tl
+          { ~ }
       }
+    \tl_if_empty:NF
+      \g_istqb_type_tl
+      { \mbox { \g_istqb_type_tl } }
+    \bool_if:nF
+      {
+        (
+          \tl_if_empty_p:N
+            \g_istqb_level_tl &&
+          \tl_if_empty_p:N
+            \g_istqb_type_tl
+        ) ||
+        (
+          \tl_if_empty_p:N
+            \g_istqb_title_tl &&
+          \tl_if_empty_p:N
+            \g_istqb_code_tl
+        )
+      }
+      { \,--\, }
     \tl_if_empty:NF
       \g_istqb_title_tl
       {
-        \tl_if_empty:NTF
-          \g_istqb_schema_tl
-          {
-            \tl_if_empty:NF
-              \g_istqb_level_tl
-              { \\ }
-          }
-          { \\ }
-        \g_istqb_title_tl
+        \mbox { \g_istqb_title_tl }
+        \tl_if_empty:NF
+          \g_istqb_code_tl
+          { ~ }
       }
+    \tl_if_empty:NF
+      \g_istqb_code_tl
+      { \mbox { ( \g_istqb_code_tl ) } }
   \end{minipage}
 }
 \rhead{%

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -77,6 +77,9 @@
 \tl_gset:Nn
   \g_istqb_logo_tl
   { istqb-logo-default }
+\tl_gset:Nn
+  \g_istqb_organization_tl
+  { ISTQB® }
 \lhead{%
   \kern 0.1in
   \fontsize{9}{10.8}\selectfont

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -219,6 +219,7 @@
     logo .tl_gset:N = \g_istqb_logo_tl,
     compatibility .tl_gset:N = \g_istqb_compatibility_tl,
     language .tl_gset:N = \g_istqb_language_tl,
+    organization .tl_gset:N = \g_istqb_organization_tl,
   }
 \tl_new:N \l_istqb_current_third_party_name_tl
 \tl_new:N \l_istqb_current_third_party_logo_tl


### PR DESCRIPTION
This PR updates the document header to match the ISTQB template 4.0 as described in ticket #53.

Here is how the new header looks in the example document:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/4c70b21b-943d-46c4-9b58-afb2125852bb)

> The title is optional, so no dash is used when missing.

All metadata keys are optional, so I made the header come out fine whichever metadata keys are missing, not just the title.