### PR TITLE
Improve the processing of answers in Sample Exam documents

### DIFF
--- a/check-yaml.lua
+++ b/check-yaml.lua
@@ -34,7 +34,15 @@ for _, filename in ipairs(arg) do
           this_failed = true
         end
       end
-    else
+    end
+    for question_no, question in pairs(output) do
+      if type(question) == 'table' and type(question['answers']) ~= nil and question['correct'] ~= nil then
+        local correct_num = type(questions['correct']) == 'table' and #questions['correct'] or 1
+        if not (#question['answers'] == 4 and correct_num == 1 or #question['answers'] == 5 and correct_num == 2) then
+          print("\nFile " .. filename .. ", question " .. question_no .. " contains " .. #question['answers'] .. " answers, out of which " .. correct_num .. " " .. (correct_num > 1 and "are" or "is") .. " marked as correct. Expected either 4 answers with 1 correct one or 5 answers with 2 correct ones.")
+          break
+        end
+      end
     end
   end
   if this_failed then

--- a/check-yaml.lua
+++ b/check-yaml.lua
@@ -35,20 +35,27 @@ for _, filename in ipairs(arg) do
         end
       end
     end
-    for question_no, question in pairs(output) do
-      if type(question) == 'table' and type(question['answers']) ~= nil and question['correct'] ~= nil then
-        local correct = question['correct']
-        local correct_num = 0
-        if type(correct) == 'string' then
-          for _ in correct:gmatch('[^,]*') do
-            correct_num = correct_num + 1
+    if output['questions'] ~= nil then
+      for question_no, question in pairs(output['questions']) do
+        if type(question) == 'table' and type(question['answers']) ~= nil and question['correct'] ~= nil then
+          local answers_num = 0
+          for _, _ in pairs(question['answers']) do
+            answers_num = answers_num + 1
           end
-        else
-          correct_num = #questions['correct']
-        end
-        if not (#question['answers'] == 4 and correct_num == 1 or #question['answers'] == 5 and correct_num == 2) then
-          print("\nFile " .. filename .. ", question " .. question_no .. " contains " .. #question['answers'] .. " answers, out of which " .. correct_num .. " " .. (correct_num > 1 and "are" or "is") .. " marked as correct. Expected either 4 answers with 1 correct one or 5 answers with 2 correct ones.")
-          break
+          local correct = question['correct']
+          local correct_num = 0
+          if type(correct) == 'string' then
+            for _ in correct:gmatch('[^,]*') do
+              correct_num = correct_num + 1
+            end
+          else
+            correct_num = #question['correct']
+          end
+          if not (answers_num == 4 and correct_num == 1 or answers_num == 5 and correct_num == 2) then
+            print("\nFile " .. filename .. ", question " .. question_no .. ", contains " .. answers_num .. " answers, out of which " .. correct_num .. " " .. (correct_num > 1 and "are" or "is") .. " marked as correct. Expected either 4 answers with 1 correct one or 5 answers with 2 correct ones.")
+            this_failed = true
+            break
+          end
         end
       end
     end

--- a/check-yaml.lua
+++ b/check-yaml.lua
@@ -37,7 +37,15 @@ for _, filename in ipairs(arg) do
     end
     for question_no, question in pairs(output) do
       if type(question) == 'table' and type(question['answers']) ~= nil and question['correct'] ~= nil then
-        local correct_num = type(questions['correct']) == 'table' and #questions['correct'] or 1
+        local correct = question['correct']
+        local correct_num = 0
+        if type(correct) == 'string' then
+          for _ in correct:gmatch('[^,]*') do
+            correct_num = correct_num + 1
+          end
+        else
+          correct_num = #questions['correct']
+        end
         if not (#question['answers'] == 4 and correct_num == 1 or #question['answers'] == 5 and correct_num == 2) then
           print("\nFile " .. filename .. ", question " .. question_no .. " contains " .. #question['answers'] .. " answers, out of which " .. correct_num .. " " .. (correct_num > 1 and "are" or "is") .. " marked as correct. Expected either 4 answers with 1 correct one or 5 answers with 2 correct ones.")
           break

--- a/template/markdownthemeistqb_sample-exam.sty
+++ b/template/markdownthemeistqb_sample-exam.sty
@@ -45,6 +45,7 @@
         \prop_gclear:N \g_istqb_answer_keys_prop
         \prop_gclear:N \g_istqb_answers_prop
       },
+      jekyllDataMappingBegin = ,
       jekyllDataSequenceBegin = {
         \str_case:nn
           { #1 }
@@ -66,6 +67,12 @@
                   },
                 }
             }
+          }
+      },
+      jekyllData(Mapping|Sequence)Begin += {
+        \str_case:nn
+          { #1 }
+          {
             { questions } {
               \group_begin:
               \markdownSetup

--- a/template/markdownthemeistqb_sample-exam.sty
+++ b/template/markdownthemeistqb_sample-exam.sty
@@ -113,9 +113,13 @@
                                   }
                                   { correct } {
                                     \group_begin:
-                                    \seq_put_right:Nn
-                                      \l_istqb_current_answer_correct_keys_seq
+                                    \clist_map_inline:nn
                                       { ####2 }
+                                      {
+                                        \seq_put_right:Nn
+                                          \l_istqb_current_answer_correct_keys_seq
+                                          { ########1 }
+                                      }
                                     \clist_set_from_seq:NN
                                       \l_istqb_current_answer_correct_keys_clist
                                       \l_istqb_current_answer_correct_keys_seq


### PR DESCRIPTION
This PR makes the following two changes to Sample Exam documents discussed in https://github.com/istqborg/istqb_product_base/issues/63#issuecomment-2156431868:

1. Validate that every question has either 4 answers with 1 correct one or 5 answers with 2 correct ones.
2. Correctly parse both `correct: a, b` (text) and `correct: [a, b]` (YAML list).
3. Fix the typesetting of the document `sample-exam.tex` from the repository `istqborg/istqb_product_template`.

Merging this PR fixes point 1 from ticket #63 and makes the fixes suggested in the following two review comments in https://github.com/istqborg/istqb-ctal-ta/pull/4 optional:

- https://github.com/istqborg/istqb-ctal-ta/pull/4/files#r1632221807
- https://github.com/istqborg/istqb-ctal-ta/pull/4/files#r1632221848

PR https://github.com/istqborg/istqb_product_template/pull/11 demonstrates the changes from this PR. It should be closed after this PR has been merged or otherwise closed.