### PR TITLE
Change the row height for answer key based on the number of answers

### DIFF
--- a/template/markdownthemeistqb_sample-exam_answers.sty
+++ b/template/markdownthemeistqb_sample-exam_answers.sty
@@ -42,6 +42,31 @@
       jekyllDataEnd = {
         \group_begin:
         % Set the dimensions of the table rows.
+        \advance
+          \@colroom
+          1.25cm
+        \int_compare:nTF
+          { \seq_count:N \g_istqb_questions_seq > 45 }
+          {
+            \cs_set:Npn
+              \arraystretch
+              { 0.95 }
+          }
+          {
+            \int_compare:nTF
+            { \seq_count:N \g_istqb_questions_seq > 40 }
+            {
+              \cs_set:Npn
+                \arraystretch
+                { 1.05 }
+            }
+            {
+              \cs_set:Npn
+                \arraystretch
+                { 1.20 }
+            }
+          }
+        % Set the dimensions of the table rows.
         \cs_set:Npn
           \arraystretch
           { 0.95 }


### PR DESCRIPTION
Since commit https://github.com/istqborg/istqb_product_base/pull/36/commits/78bd64102fff0af92eee4b3a4b75cc3b0b2c0e94 from PR https://github.com/istqborg/istqb_product_base/pull/36, the answer key now fits up to 50 answers in landscape, as discussed in https://github.com/istqborg/istqb_product_template/pull/8#issuecomment-2046969255:

![image](https://github.com/istqborg/istqb_product_template/assets/603082/2e669bb0-baa3-4b53-ac72-147892302932)

This was achieved by changing the row height.

Since this PR, if there are fewer than 50 questions, the row height is increased to improve readability and ensure a tight fit. Here are examples of 45 questions (above) and 40 questions (below):

![image](https://github.com/istqborg/istqb_product_template/assets/603082/60b90069-fdbf-4d83-a24c-66bbf17705a1)

![image](https://github.com/istqborg/istqb_product_template/assets/603082/84df0772-e28b-43f0-bd3a-cbd805f4e00d)

This change was discussed in https://github.com/istqborg/istqb_product_template/pull/8#issuecomment-2047317925 but was omitted from PR https://github.com/istqborg/istqb_product_base/pull/36 by mistake.