### PR TITLE
Allow the splitting of questions taller than 50% text height

### DIFF
--- a/template/markdownthemeistqb_sample-exam_questions.sty
+++ b/template/markdownthemeistqb_sample-exam_questions.sty
@@ -26,6 +26,8 @@
 
 % Questions
 \RequirePackage { paralist }
+\tl_new:N
+  \l_istqb_question_tl
 \markdownSetupSnippet
   { questions }
   {
@@ -40,107 +42,119 @@
         \seq_map_inline:Nn
           \g_istqb_questions_seq
           {
-            \vbox \bgroup  % Put each question in a vbox to prevent page breaks.
-            \group_begin:
-            % Print question heading.
             \tl_set:Nn
-              \l_tmpa_tl
-              { Question~\# ##1~( }
-            \prop_get:NnN
-              \g_istqb_question_number_of_points_prop
-              { ##1 }
-              \l_tmpb_tl
-            \tl_put_right:NV
-              \l_tmpa_tl
-              \l_tmpb_tl
-            \tl_put_right:Nn
-              \l_tmpa_tl
-              { ~Point }
-            \int_compare:VNnF
-              \l_tmpb_tl = { 1 }
+              \l_istqb_question_tl
               {
+                \group_begin:
+                % Print question heading.
+                \tl_set:Nn
+                  \l_tmpa_tl
+                  { Question~\# ##1~( }
+                \prop_get:NnN
+                  \g_istqb_question_number_of_points_prop
+                  { ##1 }
+                  \l_tmpb_tl
+                \tl_put_right:NV
+                  \l_tmpa_tl
+                  \l_tmpb_tl
                 \tl_put_right:Nn
                   \l_tmpa_tl
-                  { s }
-              }
-            \tl_put_right:Nn
-              \l_tmpa_tl
-              { ) }
-            \exp_args:NNV
-              \subsection *
-              \l_tmpa_tl
-            \exp_args:NVV
-              \markboth
-              \l_tmpa_tl
-              \l_tmpa_tl
-            \exp_args:NnnV
-              \addcontentsline
-              { toc }
-              { subsection }
-              \l_tmpa_tl
-            % Print question text.
-            \setdefaultleftmargin
-              { 3.2em }
-              { 2.2em }
-              { 1.87em }
-              { 1.7em }
-              { 1em }
-              { 1em }
-            \prop_item:Nn
-              \g_istqb_question_text_prop
-              { ##1 }
-            % Print answers.
-            \prop_get:NnN
-              \g_istqb_answer_keys_prop
-              { ##1 }
-              \l_tmpa_clist
-            \medskip
-            \setdefaultleftmargin
-              { 1.5em }
-              { }
-              { }
-              { }
-              { }
-              { }
-            \begin { enumerate }
-            \clist_map_inline:Nn
-              \l_tmpa_clist
-              {
-                \item [ ####1 ) ]
-                  \prop_item:Nn
-                    \g_istqb_answers_prop
-                    { ##1 / ####1 }
-              }
-            \end { enumerate }
-            \medskip
-            % Print the number of questions to select.
-            \prop_get:NnN
-              \g_istqb_answer_correct_keys_prop
-              { ##1 }
-              \l_tmpa_clist
-            \int_set:Nn
-              \l_tmpa_int
-              {
-                \clist_count:N
+                  { ~Point }
+                \int_compare:VNnF
+                  \l_tmpb_tl = { 1 }
+                  {
+                    \tl_put_right:Nn
+                      \l_tmpa_tl
+                      { s }
+                  }
+                \tl_put_right:Nn
+                  \l_tmpa_tl
+                  { ) }
+                \exp_args:NNV
+                  \subsection *
+                  \l_tmpa_tl
+                \exp_args:NVV
+                  \markboth
+                  \l_tmpa_tl
+                  \l_tmpa_tl
+                \exp_args:NnnV
+                  \addcontentsline
+                  { toc }
+                  { subsection }
+                  \l_tmpa_tl
+                % Print question text.
+                \setdefaultleftmargin
+                  { 3.2em }
+                  { 2.2em }
+                  { 1.87em }
+                  { 1.7em }
+                  { 1em }
+                  { 1em }
+                \prop_item:Nn
+                  \g_istqb_question_text_prop
+                  { ##1 }
+                % Print answers.
+                \prop_get:NnN
+                  \g_istqb_answer_keys_prop
+                  { ##1 }
                   \l_tmpa_clist
-              }
-            Select~\int_case:nnF
-              { \l_tmpa_int }
-              {
-                { 1 } { ONE }
-                { 2 } { TWO }
-                { 3 } { THREE }
-                { 4 } { FOUR }
-                { 5 } { FIVE }
-              }
-              {
-                \int_use:N
+                \medskip
+                \setdefaultleftmargin
+                  { 1.5em }
+                  { }
+                  { }
+                  { }
+                  { }
+                  { }
+                \begin { enumerate }
+                \clist_map_inline:Nn
+                  \l_tmpa_clist
+                  {
+                    \item [ ####1 ) ]
+                      \prop_item:Nn
+                        \g_istqb_answers_prop
+                        { ##1 / ####1 }
+                  }
+                \end { enumerate }
+                \medskip
+                % Print the number of questions to select.
+                \prop_get:NnN
+                  \g_istqb_answer_correct_keys_prop
+                  { ##1 }
+                  \l_tmpa_clist
+                \int_set:Nn
                   \l_tmpa_int
-              }~option\int_compare:VNnF
-              \l_tmpa_int = { 1 }
-              { s }.
-            \group_end:
-            \egroup
+                  {
+                    \clist_count:N
+                      \l_tmpa_clist
+                  }
+                Select~\int_case:nnF
+                  { \l_tmpa_int }
+                  {
+                    { 1 } { ONE }
+                    { 2 } { TWO }
+                    { 3 } { THREE }
+                    { 4 } { FOUR }
+                    { 5 } { FIVE }
+                  }
+                  {
+                    \int_use:N
+                      \l_tmpa_int
+                  }~option\int_compare:VNnF
+                  \l_tmpa_int = { 1 }
+                  { s }.
+                \group_end:
+              }
+            \vbox_set:NV
+              \l_tmpa_box
+              \l_istqb_question_tl
+            \dim_compare:nNnTF
+              { \box_ht:N \l_tmpa_box }
+              >
+              { 0.3 \paperheight }
+              { \tl_use:N \l_istqb_question_tl }
+              { \box_use:N \l_tmpa_box }
+            \par
           }
       },
     },
@@ -149,3 +163,6 @@
   \int_compare:nNn
   { VNn }
   { F }
+\cs_generate_variant:Nn
+  \vbox_set:Nn
+  { NV }


### PR DESCRIPTION
This PR makes the following change, as discussed in https://github.com/istqborg/istqb_product_base/issues/63#issuecomment-2156431868:

- Allow the splitting of questions taller than 50% text height.

This ensures that unsplittable questions will always fit a page, as discussed in https://github.com/istqborg/istqb_product_base/pull/38#issuecomment-2061994798.

Merging this PR fixes point 2 from ticket #63.