### PR TITLE
Add optional `line-numbers` metadata field that adds line numbers to generated documents

### DIFF
--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -19,6 +19,7 @@ date: YYYY/MM/DD
 release: For internal use only
 logo: istqb-logo-default
 language: en
+line-numbers: false
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -10,7 +10,7 @@ date: 2024/06/04
 release: For internal use only
 logo: istqb-logo-default
 language: en
-line-numbers: true
+line-numbers: false
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -10,7 +10,7 @@ date: 2024/06/04
 release: For internal use only
 logo: istqb-logo-default
 language: en
-line-numbers: false
+line-numbers: true
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -10,6 +10,7 @@ date: 2024/06/04
 release: For internal use only
 logo: istqb-logo-default
 language: en
+line-numbers: false
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules

--- a/schema/metadata.yml
+++ b/schema/metadata.yml
@@ -11,6 +11,7 @@ release: str(required=False)
 prefix: str(required=False)
 compatibility: str(required=False)
 language: str(required=False)
+line-numbers: bool(required=False)
 provided-by: include('third-parties', required=False)
 ---
 third-parties: list(any(str(), include('third-party')))

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -179,6 +179,10 @@
 \tl_gset:Nn
   \g_istqb_language_tl
   { en }
+\RequirePackage { lineno }
+\cs_gset:Npn
+  \linenumberfont
+  { \normalfont \normalsize \sffamily }
 \keys_define:nn
   { istqb / metadata }
   {
@@ -195,6 +199,12 @@
     compatibility .tl_gset:N = \g_istqb_compatibility_tl,
     language .tl_gset:N = \g_istqb_language_tl,
     organization .tl_gset:N = \g_istqb_organization_tl,
+    line-numbers .code:n = {
+      \tl_if_eq:nnT
+        { #1 }
+        { true }
+        { \AtBeginDocument { \linenumbers } }
+    },
   }
 \iow_new:N \g_istqb_project_name_iow
 \markdownSetupSnippet
@@ -203,7 +213,7 @@
     jekyllData,
     expectJekyllData,
     renderers = {
-      jekyllData(String|Number) = {
+      jekyllData(String|Number|Boolean) = {
         \keys_set:nn
           { istqb/metadata }
           { { #1 } = { #2 } }


### PR DESCRIPTION
This PR makes the following changes:

- Adds the optional `line-numbers` metadata field.
- Document the new metadata field in the Example Syllabus Document.

Here is how the Example Syllabus Document looks with `line-numbers: true` written in `metadata.yml`:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/ecd04414-1c30-4a6a-9aef-33750bb1f4fb)

In EPUB and HTML versions of the Example Syllabus Document, the line number are not visible, as discussed in https://github.com/istqborg/istqb_product_base/issues/54#issuecomment-2140774319.

This PR fixes items 1, 3, and 4 from https://github.com/istqborg/istqb_product_base/issues/54#issue-2323618318. As discussed in https://github.com/istqborg/istqb_product_base/issues/54#issuecomment-2154510982, we should close ticket #54 after this PR has been closed and make item 2 into a separate ticket.