### PR TITLE
Hotfix pipeline speed

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -116,6 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: witiko/markdown:3.6.0-10-g11b016ea-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Install required packages
         run: |
@@ -159,6 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: witiko/markdown:3.6.0-10-g11b016ea-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Install required packages
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v4
       - name: Install LibreOffice
+        if: github.ref == 'refs/heads/main'
         run: |
           set -ex
           if $FIND -type f -iregex '.*\.xlsx$' -print | grep -q .
@@ -101,7 +102,7 @@ jobs:
       - name: Convert EPS images to PDF
         run: $FIND -type f -iregex '.*\.eps$' -print | parallel --halt now,fail=1 epstopdf {} {.}-eps-converted-to.pdf
       - name: Convert XLSX spreadsheets to PDF
-        run: $FIND -type f -iregex '.*\.xlsx$' -print | parallel --halt now,fail=1 libreoffice7.3 --headless --convert-to pdf {} --outdir {//}
+        run: $FIND -type f -iregex '.*\.xlsx$' -print | parallel --halt now,fail=1 test ${{github.ref == 'refs/heads/main'}} = true '&&' libreoffice7.3 --headless --convert-to pdf {} --outdir {//} '||' ln -s '$(kpsewhich example-image.pdf)' {.}.pdf
       - name: Compile LaTeX documents to PDF
         run: $FIND -type f -iregex '.*\.tex$'  -print | parallel --halt now,fail=1 test -e {//}/NO_PDF '||' latexmk -r istqb_product_base/latexmkrc {} '&&' '(test {} = ./example-document.tex || mv -v {.}.pdf "$(cat {.}.istqb_project_name).pdf")'
       - name: Upload PDF documents

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{istqb}[2024/06/15 1.0.0 LaTeX class for ISTQB Documents]
+\ProvidesClass{istqb}[2024/06/25 1.1.0 LaTeX class for ISTQB Documents]
 \LoadClass[10pt]{article}
 
 % Page layout
@@ -706,6 +706,80 @@
   \currentpdfbookmark{\contentsname}{istqbtoc}%
   \tableofcontents
 }
+
+% Structure Tables
+\ExplSyntaxOn
+\tl_new:N
+  \l_istqb_external_document_basename_tl
+\int_new:N
+  \l_istqb_external_document_last_page_int
+\cs_new:Nn
+  \istqb_stucture_tables:n
+  {
+    \pdfximage
+      { #1.pdf }
+    \int_gset:Nn
+      \l_istqb_external_document_last_page_int
+      { \the\pdflastximagepages }
+    % Overview
+    \istqblandscapebegin
+    \int_compare:nNnTF
+      { \l_istqb_external_document_last_page_int } > { 3 }
+      {
+        \includegraphics
+          [
+            page = 4,
+            trim = {1.75cm~7.5cm~1.75cm~0.75cm},
+            clip,
+          ]
+          { #1 }
+      }
+      {
+        % For placeholder or incorrect inputs, display at least page 1.
+        \centering
+        \includegraphics
+          [
+            page = 1,
+            keepaspectratio,
+            width = \linewidth,
+            height = 0.5\paperheight,
+          ]
+          { #1 }
+      }
+    \istqblandscapeend
+    % Structure Tables
+    \int_step_inline:nnn
+      { 5 }
+      { \l_istqb_external_document_last_page_int }
+      {
+        \centering
+        \includegraphics
+          [
+            page = #1,
+            height = 0.7\paperheight,
+            trim = {0.75cm~0.75cm~0.75cm~0.75cm},
+            clip,
+          ]
+          { #1 }
+        \par
+      }
+  }
+\newcommand
+  \istqbstructuretables
+  [ 1 ]
+  {
+    \file_parse_full_name:nNNN
+      { #1 }
+      \l_tmpa_tl
+      \l_istqb_external_document_basename_tl
+      \l_tmpb_tl
+    \istqb_stucture_tables:V
+      \l_istqb_external_document_basename_tl
+  }
+\cs_generate_variant:Nn
+  \istqb_stucture_tables:n
+  { V }
+\ExplSyntaxOff
 
 % Unicode characters
 \RequirePackage{newunicodechar}


### PR DESCRIPTION
This PR improves the speed of the pipeline by making the following two changes:

- Only build EPUB and HTML outputs on the `main` branch, not in PRs:

    ![image](https://github.com/istqborg/istqb_product_base/assets/603082/aac6cc37-6b54-43d6-b2d6-32396e793c9e)

  This improves the build speed by ~150%.

  I have not disabled the building of DOCX outputs, since they take a constant time (~30 seconds) and disabling them won't make much difference.

- Only install LibreOffice 7.3 on the `main` branch, not in PRs. In PRs, XLSX pages in a document are replaced with [a placeholder image][1], c.f. file [`exam-structure-tables.tex`](https://github.com/istqborg/istqb_shared_documents/blob/hotfix/pipeline-speed/exam-structure-tables.tex#L24) from the repository `istqborg/istqb_shared_documents`:

  ![image](https://github.com/istqborg/istqb_product_base/assets/603082/095b3923-c507-46cc-a4ac-4d54f9ff4d61)

  This removes ~15 minutes from a build for repositories that contain XLSX documents. Currently, this only affects the repository `istqborg/istqb_shared_documents`.

The changes from this PR are just a hotfix to improve the pipeline speed before the next billing period has started. This PR continues ticket https://github.com/istqborg/istqb_product_base/issues/49 but does not close it.

[1]: http://mirrors.ctan.org/macros/latex/contrib/mwe/mwe.pdf#page=4