### PR TITLE
Docs/table column specifiers

### DIFF
--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -261,10 +261,20 @@ This will produce the following output:
  |  123  |  123 |   123  |   123   |
  |    1  |  1   |     1  |   1     |
 
-The second line of the table allows you to define the formatting of columns.
-Writing `---:`, `:---`, or `:--:` will cause the cells in the column to be typeset at their natural width with either right-aligned, left-aligned, or centered content.
-Writing `----` will stretch the column to the page width and left-align its content.
-If you write `----` for several columns, each will stretch to a uniform portion of the remaining page width.
+The second line of the table allows you to define the formatting of columns:
+
+- Writing `---:`, `:---`, or `:--:` will cause the cells in the column to be
+  typeset at their natural width with either right-aligned, left-aligned, or
+  centered content, respectively. The cells will not wrap over multiple lines
+  and should therefore contain short texts with a couple of words at most.
+
+- Writing `----` will stretch the column to the page width and left-align its
+  content. If you write `----` for several columns, each will stretch to a
+  uniform portion of the remaining page width. The cells will wrap over
+  multiple lines and are therefore well-suited for long paragraphs of text.
+
+If your table overflows a page, make sure that all columns with long texts
+are specified as `----`, not as `---:`, `:---`, or `:--:`.
 
 You can add a caption to the table as follows:
 

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -1,6 +1,10 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{istqb}[2024/06/25 1.1.0 LaTeX class for ISTQB Documents]
+\ProvidesClass{istqb}[2024/07/03 1.2.0 LaTeX class for ISTQB Documents]
+
+% Fonts
 \LoadClass[10pt]{article}
+\usepackage{microtype}
+\DisableLigatures[-]{family=tt*}
 
 % Page layout
 %% Page geometry


### PR DESCRIPTION
Here is the documentation of markdown tables after this PR:

![image](https://github.com/istqborg/istqb_product_base/assets/603082/b01d6497-98c2-480f-978c-6a210274b3d7)

The updated documentation clarifies how the different column types affect wrapping and how to prevent overflows.

Closes #60.