### PR TITLE
Support markdown question definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ To typeset ISTQB documents on your computer, take the following steps:
    $ docker run --rm -it ghcr.io/istqborg/istqb_product_base --help
    ```
    ```
-   usage: template.py [-h] {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,convert-to-docx} ...
+   usage: template.py [-h]
+                   {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx} ...
 
    Process ISTQB documents written with the LaTeX+Markdown template
 
    positional arguments:
-     {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,convert-to-docx}
+     {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx}
        find-files          Produce a newline-separated list of different types of files in this repository
        fixup-languages     Determine and add `babel-language` to language definitions if missing
        fixup-line-endings  Convert all text files to Unix-style line endings
@@ -56,6 +57,10 @@ To typeset ISTQB documents on your computer, take the following steps:
        convert-eps-to-pdf  Convert all EPS files in this repository to PDF
        convert-xlsx-to-pdf
                            Convert all XLSX files in this repository to PDF
+       convert-md-questions-to-yaml
+                           Convert all MD files with questions definitions to YAML
+       convert-yaml-questions-to-md
+                           Convert all YAML files with questions definitions to MD
        compile-tex-to-pdf  Compile all TeX files in this repository to PDF
        compile-tex-to-html
                            Compile all TeX files in this repository to HTML

--- a/schema/questions.yml
+++ b/schema/questions.yml
@@ -1,8 +1,10 @@
-duration: [int(), int()]  # minutes
-num-questions: int()
-max-score: int()
-pass-score: int()  # percent
+duration: include('duration', required=False)
+num-questions: int(required=False)
+max-score: int(required=False)
+pass-score: int(required=False)  # percent
 questions: map(include('question'), key=any(str(), int()))
+---
+duration: [int(), int()]  # minutes
 ---
 question:
   learning-objective: str()

--- a/template.py
+++ b/template.py
@@ -419,7 +419,7 @@ def _convert_md_questions_to_yaml() -> None:
         output_path = input_path.with_suffix('.yml')
         if output_path.exists():
             LOGGER.warning('Skipping creation of existing file "%s"', output_path)
-            return
+            continue
 
         output_yaml = {'questions': dict(_read_md_questions(input_path))}
 
@@ -445,7 +445,7 @@ def _convert_yaml_questions_to_md() -> None:
         output_path = input_path.with_suffix('.md')
         if output_path.exists():
             LOGGER.warning('Skipping creation of existing file "%s"', output_path)
-            return
+            continue
 
         with input_path.open('rt') as f:
             input_yaml_text = f.read()

--- a/template.py
+++ b/template.py
@@ -247,7 +247,7 @@ def _fixup_language(path: Path) -> None:
     # Add `babel-language` on top of the language definitions.
     LOGGER.info('Added "babel-language: %s" to file "%s"', babel_name, path)
     with path.open('wt') as wf:
-        print(f'babel-language: {json.dumps(babel_name)}', file=wf)
+        print(f'babel-language: {json.dumps(babel_name, ensure_ascii=False)}', file=wf)
         wf.write(input_yaml_text)
 
 
@@ -420,7 +420,16 @@ def _convert_md_questions_to_yaml() -> None:
             LOGGER.warning('Found no questions in file "%s", skipping creation of empty file "%s"', input_path, output_path)
         else:
             with output_path.open('wt') as f:
-                json.dump(output_yaml, f, indent=4)
+                print('questions:', file=f)
+                for question_number, question in sorted(output_yaml['questions'].items()):
+                    print(f'  {question_number}:', file=f)
+                    print(f'    learning-objective: {json.dumps(question["learning-objective"], ensure_ascii=False)}', file=f)
+                    print(f'    k-level: {json.dumps(question["k-level"], ensure_ascii=False)}', file=f)
+                    print(f'    number-of-points: {json.dumps(question["number-of-points"], ensure_ascii=False)}', file=f)
+                    print(f'    question: {json.dumps(question["question"], ensure_ascii=False)}', file=f)
+                    print(f'    answers: {json.dumps(question["answers"], ensure_ascii=False)}', file=f)
+                    print(f'    correct: {json.dumps(question["correct"], ensure_ascii=False)}', file=f)
+                    print(f'    explanation: {json.dumps(question["explanation"], ensure_ascii=False)}', file=f)
                 LOGGER.info('Converted file "%s" to "%s"', input_path, output_path)
 
 

--- a/template.py
+++ b/template.py
@@ -466,7 +466,7 @@ def _convert_yaml_questions_to_md() -> None:
                 print(file=f)
                 print('## answers', file=f)
                 for answer_index, (answer_letter, answer) in enumerate(sorted(question['answers'].items())):
-                    answer = answer.rstrip('\r\n')
+                    answer = str(answer).rstrip('\r\n')
                     print(f'{answer_index + 1}. {answer}', file=f)
                 print(file=f)
                 print('## justification', file=f)

--- a/template.py
+++ b/template.py
@@ -433,6 +433,39 @@ def _convert_md_questions_to_yaml() -> None:
                 LOGGER.info('Converted file "%s" to "%s"', input_path, output_path)
 
 
+def _convert_yaml_questions_to_md() -> None:
+    for input_path in _find_files(['questions-yaml']):
+        output_path = input_path.with_suffix('.md')
+        if output_path.exists():
+            LOGGER.warning('Skipping creation of existing file "%s"', output_path)
+            return
+
+        with input_path.open('rt') as f:
+            input_yaml_text = f.read()
+        input_yaml = yaml.safe_load(input_yaml_text)
+
+        with output_path.open('wt') as f:
+            for question_index, (question_number, question) in enumerate(sorted(input_yaml['questions'].items())):
+                if question_index > 0:
+                    print(file=f)
+                print('# metadata', file=f)
+                print(f'lo: {question["learning-objective"]}', file=f)
+                print(f'k-level: {question["k-level"]}', file=f)
+                print(f'points: {question["number-of-points"]}', file=f)
+                print(f'correct: {question["correct"]}', file=f)
+                print(file=f)
+                print('## question', file=f)
+                print(question['question'], file=f)
+                print(file=f)
+                print('## answers', file=f)
+                for answer_index, (answer_letter, answer) in enumerate(sorted(question['answers'].items())):
+                    print(f'{answer_index + 1}. {answer}', file=f)
+                print(file=f)
+                print('## justification', file=f)
+                print(question['explanation'], file=f)
+            LOGGER.info('Converted file "%s" to "%s"', input_path, output_path)
+
+
 @lru_cache(maxsize=None)
 def _changed_paths(base_branch='origin/main') -> List[Path]:
     if CURRENT_REPOSITORY is None:
@@ -804,6 +837,10 @@ def convert_md_questions_to_yaml(args: Namespace) -> None:
     _convert_md_questions_to_yaml()
 
 
+def convert_yaml_questions_to_md(args: Namespace) -> None:
+    _convert_yaml_questions_to_md()
+
+
 def compile_tex_files_to_pdf(args: Namespace) -> None:
     _compile_tex_files_to_pdf()
 
@@ -872,6 +909,12 @@ def main():
         help='Convert all MD files with questions definitions to YAML',
     )
     parser_convert_md_questions_to_yaml.set_defaults(func=convert_md_questions_to_yaml)
+
+    parser_convert_yaml_questions_to_md = subparsers.add_parser(
+        'convert-yaml-questions-to-md',
+        help='Convert all YAML files with questions definitions to MD',
+    )
+    parser_convert_yaml_questions_to_md.set_defaults(func=convert_yaml_questions_to_md)
 
     parser_compile_tex_to_pdf = subparsers.add_parser(
         'compile-tex-to-pdf',

--- a/template.py
+++ b/template.py
@@ -143,7 +143,7 @@ def _find_files(file_types: Iterable[str], tex_input_paths: Optional[Iterable[Pa
                 return False, None
             return True, path
 
-        def prune_subdirectory(subdirectory: str) -> bool:
+        def keep_subdirectory(subdirectory: str) -> bool:
             if subdirectory.startswith('.'):
                 return False
             if subdirectory == 'istqb_product_base' and 'languages' not in file_types:
@@ -155,7 +155,7 @@ def _find_files(file_types: Iterable[str], tex_input_paths: Optional[Iterable[Pa
         removed_subdirectory_indexes = [
             index
             for index, subdirectory in enumerate(subdirectories)
-            if not prune_subdirectory(subdirectory)
+            if not keep_subdirectory(subdirectory)
         ]
         for index in sorted(removed_subdirectory_indexes, reverse=True):
             del subdirectories[index]
@@ -206,7 +206,7 @@ def _fixup_language(path: Path) -> None:
         input_yaml_text = rf.read()
     input_yaml = yaml.safe_load(input_yaml_text)
     if 'babel-language' in input_yaml:
-        LOGGER.debug('File %s already contains `babel-language`', path)
+        LOGGER.debug('File "%s" already contains `babel-language`', path)
         return
 
     # Determine the babel name of the language.

--- a/template.py
+++ b/template.py
@@ -462,14 +462,15 @@ def _convert_yaml_questions_to_md() -> None:
                 print(f'correct: {question["correct"]}', file=f)
                 print(file=f)
                 print('## question', file=f)
-                print(question['question'], file=f)
+                print(question['question'].rstrip('\r\n'), file=f)
                 print(file=f)
                 print('## answers', file=f)
                 for answer_index, (answer_letter, answer) in enumerate(sorted(question['answers'].items())):
+                    answer = answer.rstrip('\r\n')
                     print(f'{answer_index + 1}. {answer}', file=f)
                 print(file=f)
                 print('## justification', file=f)
-                print(question['explanation'], file=f)
+                print(question['explanation'].rstrip('\r\n'), file=f)
             LOGGER.info('Converted file "%s" to "%s"', input_path, output_path)
 
 

--- a/template.py
+++ b/template.py
@@ -65,8 +65,8 @@ MARKDOWN_REGEXP = re.compile(r'\.(md|mdown|markdown)$', flags=re.IGNORECASE)
 YAML_REGEXP = re.compile(r'\.ya?ml$', flags=re.IGNORECASE)
 TEMPLATE_REGEXP = re.compile(r'\.(sty|cls|lua)$', flags=re.IGNORECASE)
 
-METADATA_REGEXP = re.compile(r'metadata\.ya?ml', flags=re.IGNORECASE)
-QUESTIONS_REGEXP = re.compile(r'questions\.ya?ml', flags=re.IGNORECASE)
+METADATA_REGEXP = re.compile(r'metadata.*\.ya?ml', flags=re.IGNORECASE)
+QUESTIONS_REGEXP = re.compile(r'questions.*\.ya?ml', flags=re.IGNORECASE)
 LANGUAGES_REGEXP = re.compile(r'..\.ya?ml', flags=re.IGNORECASE)
 
 

--- a/template.py
+++ b/template.py
@@ -771,13 +771,6 @@ def find_files(args: Namespace) -> None:
         print(path)
 
 
-def find_directories(args: Namespace) -> None:
-    file_types = [args.dirtype]
-    paths = sorted(_find_directories(file_types=file_types))
-    for path in paths:
-        print(path)
-
-
 def fixup_languages(args: Namespace) -> None:
     _fixup_languages()
 


### PR DESCRIPTION
This PR makes the following changes:

- During compilation to PDF, auto-convert files `questions.md` to `questions.yml` unless `questions.yml` already exists.
- Auto-convert files `questions.yml` from the following repositories to `questions.md` and test that the round trip from `questions.yml` to `questions.md` and back does not affect the typeset output:
  - `istqb_product_template`, see https://github.com/istqborg/istqb_product_template/pull/15
  - CT-TAE, see https://github.com/istqborg/istqb-ct-tae/pull/6
  - CT-TAS, see https://github.com/istqborg/istqb-ct-tas/pull/6
  - CT-QDO, see https://github.com/istqborg/istqb-ct-qdo/pull/24
  - CTFL, see https://github.com/istqborg/istqb-ctfl/pull/16
- Remove file `questions.yml` from branch `questions_redesign` of the repository CTAL-TA and test that this does not affect the typeset output, see https://github.com/istqborg/istqb-ctal-ta/pull/6

This PR closes #70.