### PR TITLE
Reduce space above Keywords and Learning Objectives

### DIFF
--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -419,7 +419,6 @@
         \istqbsubsubsection { #1 }
       },
       headingFour = {
-        \par\kern 0.1in\relax
         \paragraph { #1 }
         \leavevmode
       },


### PR DESCRIPTION
Closes "Chapter intro needs to fit on a single page" (#83) by reducing the space above **Keywords** and **Learning Objectives**:

![image](https://github.com/user-attachments/assets/c53156e4-4c3f-41f7-b587-e71235e3e1af)

See also https://github.com/istqborg/istqb_product_base/issues/83#issuecomment-2262746620.