### PR TITLE
Support programmatic text in YAML metadata values

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: witiko/markdown
-          ref: 3.6.2
+          ref: 43ef5d4
           fetch-depth: 0
       - name: Build intermediate image witiko/markdown:latest-minimal
         run: DOCKER_BUILDKIT=1 docker build --build-arg TEXLIVE_TAG=latest-minimal --build-arg DEV_IMAGE=true -t witiko/markdown:latest-minimal .

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: witiko/markdown
-          ref: 43ef5d4
+          ref: 3.7.0-dev.0
           fetch-depth: 0
       - name: Build intermediate image witiko/markdown:latest-minimal
         run: DOCKER_BUILDKIT=1 docker build --build-arg TEXLIVE_TAG=latest-minimal --build-arg DEV_IMAGE=true -t witiko/markdown:latest-minimal .

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -48,6 +48,7 @@ jobs:
       - flake8
       - pytype
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Git repository witiko/markdown
         uses: actions/checkout@v4

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -48,7 +48,6 @@ jobs:
       - flake8
       - pytype
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Git repository witiko/markdown
         uses: actions/checkout@v4

--- a/check-yaml.lua
+++ b/check-yaml.lua
@@ -6,9 +6,7 @@ kpse.set_program_name("luatex")
 local tinyyaml = require("markdown-tinyyaml")
 local file, input, output, ran_ok, err
 local some_failed = false
-local this_failed
 for _, filename in ipairs(arg) do
-  this_failed = false
   file = assert(io.open(arg[1], "r"))
   input = assert(file:read("*a"))
   ran_ok, err = pcall(function()
@@ -16,51 +14,9 @@ for _, filename in ipairs(arg) do
   end)
   if not ran_ok then
     print("File " .. filename .. " is not well-formed: " .. err)
-    this_failed = true
+    some_failed = true
   elseif not output then
     print("File " .. filename .. " contained no data.")
-    this_failed = true
-  else
-    if output.logo ~= nil and string.find(output.logo, "_") then
-      print("\nFile " .. filename .. " contains `logo: " .. output.logo .. "`, which contains underscores (`_`).")
-      print("Underscores cause issues, see <https://github.com/istqborg/istqb_product_base/issues/46>. Please, remove them.\n")
-      this_failed = true
-    end
-    if output['provided-by'] ~= nil then
-      for i, provided_by in ipairs(output['provided-by']) do
-        if provided_by.logo ~= nil and string.find(provided_by.logo, "_") then
-          print("\nFile " .. filename .. " contains `provided_by[" .. i .. "].logo: " .. provided_by.logo .. "`, which contains underscores (`_`).")
-          print("Underscores cause issues, see <https://github.com/istqborg/istqb_product_base/issues/46>. Please, remove them.\n")
-          this_failed = true
-        end
-      end
-    end
-    if output['questions'] ~= nil then
-      for question_no, question in pairs(output['questions']) do
-        if type(question) == 'table' and type(question['answers']) ~= nil and question['correct'] ~= nil then
-          local answers_num = 0
-          for _, _ in pairs(question['answers']) do
-            answers_num = answers_num + 1
-          end
-          local correct = question['correct']
-          local correct_num = 0
-          if type(correct) == 'string' then
-            for _ in correct:gmatch('[^,]*') do
-              correct_num = correct_num + 1
-            end
-          else
-            correct_num = #question['correct']
-          end
-          if not (answers_num == 4 and correct_num == 1 or answers_num == 5 and correct_num == 2) then
-            print("\nFile " .. filename .. ", question " .. question_no .. ", contains " .. answers_num .. " answers, out of which " .. correct_num .. " " .. (correct_num > 1 and "are" or "is") .. " marked as correct. Expected either 4 answers with 1 correct one or 5 answers with 2 correct ones.")
-            this_failed = true
-            break
-          end
-        end
-      end
-    end
-  end
-  if this_failed then
     some_failed = true
   else
     print("File " .. filename .. " is well-formed.")

--- a/template.py
+++ b/template.py
@@ -195,7 +195,7 @@ def _fixup_languages() -> None:
 
 def _run_command(*args: str, text=False, timeout=60) -> Union[str, bytes]:
     try:
-        output = subprocess.check_output(args, text=text, stderr=subprocess.STDOUT)
+        output = subprocess.check_output(args, text=text, stderr=subprocess.STDOUT, timeout=timeout)
     except subprocess.CalledProcessError as e:
         try:
             output = e.output.decode()

--- a/template.py
+++ b/template.py
@@ -193,7 +193,7 @@ def _fixup_languages() -> None:
         _fixup_language(path)
 
 
-def _run_command(*args: str, text=False) -> Union[str, bytes]:
+def _run_command(*args: str, text=False, timeout=60) -> Union[str, bytes]:
     try:
         output = subprocess.check_output(args, text=text, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
@@ -651,7 +651,7 @@ def _should_compile_tex_file_to_docx(input_path: Path) -> bool:
 def _compile_tex_file_to_pdf(input_path: Path) -> Optional[Path]:
     if not _should_compile_tex_file_to_pdf(input_path):
         return
-    _run_command('latexmk', '-gg', '-r', f'{LATEXMKRC}', f'{input_path}')
+    _run_command('latexmk', '-gg', '-r', f'{LATEXMKRC}', f'{input_path}', timeout=600)
     if input_path != EXAMPLE_DOCUMENT:
         with input_path.with_suffix('.istqb_project_name').open('rt') as f:
             project_name = f.read().strip()
@@ -666,7 +666,7 @@ def _compile_tex_file_to_html(input_path: Path, output_directory: Path) -> Optio
     if not _should_compile_tex_file_to_html(input_path):
         return
     output_path = output_directory / input_path.stem / input_path.with_suffix('.html').name
-    _run_command('make4ht', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_path.parent}', f'{input_path}')
+    _run_command('make4ht', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_path.parent}', f'{input_path}', timeout=600)
     return output_path
 
 
@@ -686,7 +686,7 @@ def _compile_tex_file_to_epub(input_path: Path, output_directory: Path) -> Optio
     shutil.copytree(input_path.parent, build_directory, ignore=prune_output_directory)
 
     with _change_directory(build_directory):
-        _run_command('tex4ebook', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_directory}', input_path.name)
+        _run_command('tex4ebook', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_directory}', input_path.name, timeout=600)
 
     shutil.rmtree(build_directory)
 

--- a/template.py
+++ b/template.py
@@ -686,7 +686,10 @@ def _compile_tex_file_to_epub(input_path: Path, output_directory: Path) -> Optio
     shutil.copytree(input_path.parent, build_directory, ignore=prune_output_directory)
 
     with _change_directory(build_directory):
-        _run_command('tex4ebook', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_directory}', input_path.name, timeout=600)
+        _run_command(
+            'tex4ebook', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_directory}', input_path.name,
+            timeout=600,
+        )
 
     shutil.rmtree(build_directory)
 

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -78,7 +78,8 @@
       jekyllData(Sequence|Mapping)End = {
         \group_end:
       },
-      jekyllDataString = {
+      jekyllDataTypographicString = ,
+      jekyllDataProgrammaticString = {
         \tl_set:Nx
           \l_tmpa_tl
           { { \l_istqb_language_position #1 } }
@@ -225,7 +226,8 @@
     expectJekyllData,
     ensureJekyllData,
     renderers = {
-      jekyllData(String|Number|Boolean) = {
+      jekyllDataTypographicString = ,
+      jekyllData(ProgrammaticString|Number|Boolean) = {
         \keys_set:nn
           { istqb/metadata }
           { { #1 } = { #2 } }
@@ -294,7 +296,7 @@
   { metadata / provided-by }
   {
     renderers = {
-      jekyllData(String|Number) = {
+      jekyllData(ProgrammaticString|Number) = {
         % Short-hand definition
         \seq_gput_right:Nn
           \g_istqb_third_parties_seq
@@ -332,7 +334,7 @@
   { metadata / provided-by / verbose }
   {
     renderers = {
-      jekyllData(String|Number) = {
+      jekyllData(ProgrammaticString|Number) = {
         \keys_set:nn
           { istqb / metadata / provided-by }
           { { #1 } = { #2 } }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesExplPackage
   {markdownthemeistqb_common}%
-  {2024-06-15}%
+  {2024-08-09}%
   {1.0.0}%
   {LaTeX theme for the Markdown Package that contains common code for different types of ISTQB documents}
 
@@ -62,6 +62,7 @@
   {
     jekyllData,
     expectJekyllData,
+    ensureJekyllData,
     renderers = {
       jekyllData(Sequence|Mapping)Begin = {
         \group_begin:
@@ -222,6 +223,7 @@
   {
     jekyllData,
     expectJekyllData,
+    ensureJekyllData,
     renderers = {
       jekyllData(String|Number|Boolean) = {
         \keys_set:nn

--- a/template/markdownthemeistqb_sample-exam.tex
+++ b/template/markdownthemeistqb_sample-exam.tex
@@ -43,7 +43,8 @@
         \seq_gclear:N
           \g_istqb_questions_seq
       },
-      jekyllData(String|Number) = {
+      jekyllDataProgrammaticString = ,
+      jekyllData(TypographicString|Number) = {
         \keys_set:nn
           { istqb / questions }
           { { #1 } = { #2 } }
@@ -58,7 +59,7 @@
                 {
                   code = \group_begin:,
                   renderers = {
-                    jekyllData(String
+                    jekyllData(TypographicString
                               |Number) = {
                       \keys_set:nn
                         { istqb / questions /
@@ -205,7 +206,7 @@
   { questions / * }
   {
     renderers = {
-      jekyllData(String|Number) = {
+      jekyllData(TypographicString|Number) = {
         \keys_set:nn
           { istqb / questions / * }
           { { #1 } = { #2 } }
@@ -265,7 +266,7 @@
   { questions / * / answers }
   {
     renderers = {
-      jekyllData(String|Number) = {
+      jekyllData(TypographicString|Number) = {
         \seq_put_right:Nn
           \l_istqb_current_answer_keys_seq
           { #1 }
@@ -295,7 +296,7 @@
   { questions / * / correct }
   {
     renderers = {
-      jekyllData(String|Number) = {
+      jekyllData(TypographicString|Number) = {
         \seq_put_right:cn
           { l_istqb_current_answer_correct
             _keys_seq }

--- a/template/markdownthemeistqb_sample-exam.tex
+++ b/template/markdownthemeistqb_sample-exam.tex
@@ -1,6 +1,6 @@
 \ProvidesExplFile
   {markdownthemeistqb_sample-exam.tex}%
-  {2024-06-15}
+  {2024-08-09}
   {1.0.0}
   {LaTeX theme for the Markdown Package that typesets ISTQB Sample Exam Questions and Answers documents}
 
@@ -37,6 +37,7 @@
   {
     jekyllData,
     expectJekyllData,
+    ensureJekyllData,
     renderers = {
       jekyllDataBegin = {
         \seq_gclear:N


### PR DESCRIPTION
This PR makes the following changes:

- Produce an error when a YAML file cannot be parsed rather than typesetting it as Markdown text.
  Malformed YAML files would be caught by validation anyways but this is an extra safety net.
- Only allow Markdown markup in question definitions not in metadata or in language definitions.
    - No longer check for the presence of `_` in logo metadata values during YAML validation in the CI.
      Since Markdown markup is not used in metadata, logos may now contain `_`s in their filenames.

This PR also makes the following unrelated changes:

- Time out compilation after 10 minutes and other commands after 1 minute.
  This prevents the CI from only timing out after two hours in case of an infinite loop.

This PR closes #46.