### PR TITLE
Update footer to match new ISTQB template

### DIFF
--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -234,7 +234,6 @@
       \fontsize{6}{6}\selectfont
       \textcopyright{}~\istqborgname
     \end{mdframed}
-    \vspace{24.25pt}
   }
 \box_new:N \l_istqb_footer_box
 \AtBeginDocument

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -234,6 +234,7 @@
       \fontsize{6}{6}\selectfont
       \textcopyright{}~\istqborgname
     \end{mdframed}
+    \vspace{24.25pt}
   }
 \box_new:N \l_istqb_footer_box
 \AtBeginDocument

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -193,7 +193,7 @@
     ]
       \fontsize{9}{10.8}\selectfont
       \begin{minipage}{0.4\linewidth}
-      \mbox{\g_istqb_version_tl}
+      \mbox{\g_istqb_version_tl{}~\g_istqb_release_tl}
       \end{minipage}
       \begin{minipage}{0.2\linewidth}
       \centering
@@ -230,19 +230,7 @@
       \hfill
       \mbox{\g_istqb_date_tl}
       \end{minipage}
-      \\
-      \mbox{\g_istqb_release_tl}
-    \end{mdframed}
-    \begin{mdframed}[
-      linewidth=0.75pt,
-      linecolor=black!25!white,
-      innerleftmargin=0.08in,
-      innerrightmargin=8pt,
-      innertopmargin=3pt,
-      innerbottommargin=3pt,
-      skipabove=\baselineskip,
-      rightmargin=-8pt,
-    ]
+      \\[5pt]
       \fontsize{6}{6}\selectfont
       \textcopyright{}~\istqborgname
     \end{mdframed}


### PR DESCRIPTION
This PR updates the footer to match new ISTQB template.

Here is how the footer of the example document looks before and after this PR:

![image](https://github.com/user-attachments/assets/c7136f29-2f87-4e29-b5de-e7497a19e152)
![image](https://github.com/user-attachments/assets/1528192e-fa2e-4fd6-8450-63f26558ea24)

The new footer gives us space for ~2 more text lines in the body text. In commit 97aaf3e81b8ba46fb65c6c4ffbaf6582b6e4c0d4, I raised the footer, so that there are no extra text lines in the body text and we don't change page breaks in existing documents.

@danopolan, would you rather stay backwards-compatible or have more space for the body text? Having more space for the body text will improve the placement of tables, among other things, but it may require another review of previously reviewed documents. If we wish to have more space for the body text, we should revert commit 97aaf3e81b8ba46fb65c6c4ffbaf6582b6e4c0d4 before merging this PR.

This PR closes #92.