### PR TITLE
Remove questions in YAML format from DOCX output

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -12,6 +12,8 @@ imakeidx
 lastpage
 latexmk
 lipsum
+luaxml
+make4ht
 makeindex
 mdframed
 needspace

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -20,6 +20,7 @@ needspace
 newunicodechar
 supertabular
 tex-gyre
+tex4ebook
 titlesec
 tocbibind
 zref

--- a/template.py
+++ b/template.py
@@ -696,7 +696,9 @@ def _compile_tex_file_to_epub(input_path: Path, output_directory: Path) -> Optio
 
     shutil.rmtree(build_directory)
 
-    output_path = output_directory / input_path.with_suffix('.epub').name
+    project_name = _get_project_name(input_path)
+    output_path = output_directory / f'{project_name}.epub'
+    (output_directory / input_path.with_suffix('.epub').name).rename(output_path)
     return output_path
 
 

--- a/template.py
+++ b/template.py
@@ -600,6 +600,9 @@ def _should_compile_tex_file_to_docx(input_path: Path) -> bool:
     if (input_path.parent / input_path.stem / 'NO_DOCX').exists():
         return False
 
+    if _is_sample_exam_answers(input_path):
+        return False
+
     metadata_path = _get_metadata_path(input_path, 'determine whether it should be compiled to DOCX; will not compile')
     if metadata_path is None:
         return False

--- a/template.py
+++ b/template.py
@@ -537,7 +537,7 @@ def _should_compile_tex_file_to_pdf(input_path: Path) -> bool:
     metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'pdf-output' in metadata_yaml:
-        pdf_output = bool(metadata_yaml['pdf_output'])
+        pdf_output = bool(metadata_yaml['pdf-output'])
         return pdf_output
 
     return True
@@ -560,7 +560,7 @@ def _should_compile_tex_file_to_html(input_path: Path) -> bool:
     metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'html-output' in metadata_yaml:
-        html_output = bool(metadata_yaml['html_output'])
+        html_output = bool(metadata_yaml['html-output'])
         return html_output
     if 'version' in metadata_yaml:
         version = str(metadata_yaml['version'])
@@ -584,10 +584,10 @@ def _should_compile_tex_file_to_epub(input_path: Path) -> bool:
     metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'epub-output' in metadata_yaml:
-        epub_output = bool(metadata_yaml['epub_output'])
+        epub_output = bool(metadata_yaml['epub-output'])
         return epub_output
     if 'html-output' in metadata_yaml:
-        html_output = bool(metadata_yaml['html_output'])
+        html_output = bool(metadata_yaml['html-output'])
         return html_output
     if 'version' in metadata_yaml:
         version = str(metadata_yaml['version'])
@@ -612,7 +612,7 @@ def _should_compile_tex_file_to_docx(input_path: Path) -> bool:
     metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'docx-output' in metadata_yaml:
-        docx_output = bool(metadata_yaml['docx_output'])
+        docx_output = bool(metadata_yaml['docx-output'])
         return docx_output
     if 'version' in metadata_yaml:
         version = str(metadata_yaml['version'])

--- a/template.py
+++ b/template.py
@@ -618,6 +618,14 @@ def _should_compile_tex_file_to_docx(input_path: Path) -> bool:
     return False
 
 
+def _is_sample_exam_questions(input_path: Path) -> bool:
+    return 'questions' in input_path.name
+
+
+def _is_sample_exam_answers(input_path: Path) -> bool:
+    return 'answers' in input_path.name
+
+
 def _get_project_name(input_path: Path) -> str:
     basename = input_path.stem
     if input_path == EXAMPLE_DOCUMENT:
@@ -633,6 +641,10 @@ def _get_project_name(input_path: Path) -> str:
     organization = metadata_yaml.get('organization', 'ISTQB®').replace('®', '').strip()
     code = metadata_yaml.get('code', 'CODE').strip()
     document_type = metadata_yaml.get('type', 'TYPE').strip()
+    if _is_sample_exam_questions(input_path):
+        document_type = f'{document_type} Questions'
+    elif _is_sample_exam_answers(input_path):
+        document_type = f'{document_type} Answers'
     version = metadata_yaml.get('version', 'VERSION').strip()
     language = metadata_yaml.get('language', 'en').upper().strip()
     project_name = f'{organization}-{code}-{document_type}-{version}-{language}'

--- a/template.py
+++ b/template.py
@@ -719,7 +719,8 @@ def _compile_tex_file_to_docx(input_path: Path, output_directory: Path) -> Optio
     # Convert the collected files to DOCX.
     markdown_text = '\n\n'.join(markdown_texts)
     pandoc_from_format = '+'.join([PANDOC_INPUT_FORMAT, *PANDOC_EXTENSIONS])
-    output_path = output_directory / input_path.with_suffix('.docx').name
+    project_name = _get_project_name(input_path)
+    output_path = output_directory / f'{project_name}.docx'
     with NamedTemporaryFile('wt', delete=False) as f:
         print(markdown_text, file=f)
         f.close()

--- a/template.py
+++ b/template.py
@@ -708,7 +708,7 @@ def _compile_tex_file_to_docx(input_path: Path, output_directory: Path) -> Optio
             with nested_path.open('rt') as f:
                 markdown_text = f.read()
                 markdown_texts.append(markdown_text)
-        elif YAML_REGEXP.search(nested_path.name):
+        elif YAML_REGEXP.search(nested_path.name) and not QUESTIONS_YAML_REGEXP.fullmatch(nested_path.name):
             with nested_path.open('rt') as f:
                 markdown_text = f'``` yml\n{f.read()}\n```'
                 markdown_texts.append(markdown_text)

--- a/template.py
+++ b/template.py
@@ -667,7 +667,8 @@ def _compile_tex_file_to_pdf(input_path: Path) -> Optional[Path]:
 def _compile_tex_file_to_html(input_path: Path, output_directory: Path) -> Optional[Path]:
     if not _should_compile_tex_file_to_html(input_path):
         return
-    output_path = output_directory / input_path.stem / input_path.with_suffix('.html').name
+    project_name = _get_project_name(input_path)
+    output_path = output_directory / project_name / input_path.with_suffix('.html').name
     _run_command('make4ht', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_path.parent}', f'{input_path}', timeout=600)
     return output_path
 

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -218,7 +218,6 @@
     epub-output .code:n = { },
     html-output .code:n = { },
   }
-\iow_new:N \g_istqb_project_name_iow
 \markdownSetupSnippet
   { metadata }
   {
@@ -256,27 +255,6 @@
       jekyllDataEnd = {
         \istqb_load_language:V
           \g_istqb_language_tl
-        \iow_open:Ne
-          \g_istqb_project_name_iow
-          { \c_sys_jobname_str .istqb_project_name }
-        \str_set:NV
-          \l_tmpa_str
-          \g_istqb_organization_tl
-        \str_remove_all:Nn
-          \l_tmpa_str
-          { ® }
-        \iow_now:Ne
-          \g_istqb_project_name_iow
-          {
-            \l_tmpa_str -
-            \g_istqb_code_tl -
-            \g_istqb_type_tl -
-            \g_istqb_version_tl -
-            \str_uppercase:V
-              \g_istqb_language_tl
-          }
-        \iow_close:N
-          \g_istqb_project_name_iow
       },
     },
   }


### PR DESCRIPTION
This PR makes the following changes:

- Remove questions in YAML format from DOCX output.
- Use project name generated from metadata for DOCX, HTML, and EPUB output.
- Do not convert Sample Exam Answers to DOCX, only Questions:
- Produce distinctly named PDF, HTML, and EPUB files for Sample Exam Questions and Answers.

Here is an example of running the compilation to PDF, DOCX, HTML, and EPUB on the CTAL-TA repository:
```
root@c7df818d3e71:/mnt# istqb-template compile-tex-to-pdf
Compiled file "/mnt/sample-exam-questions.tex" to "ISTQB-CTAL-TA-Sample Exam A Questions-v4.0-EN.pdf"
Compiled file "/mnt/sample-exam-answers.tex" to "ISTQB-CTAL-TA-Sample Exam A Answers-v4.0-EN.pdf"
```
```
root@c7df818d3e71:/mnt# istqb-template compile-tex-to-docx docx
Skipped the compilation of file "/mnt/sample-exam-answers.tex" because it has been disabled
Compiled file "/mnt/sample-exam-questions.tex" to "docx/ISTQB-CTAL-TA-Sample Exam A Questions-v4.0-EN.docx"
```
```
root@c7df818d3e71:/mnt# istqb-template compile-tex-to-html html
Compiled file "/mnt/sample-exam-questions.tex" to "html/ISTQB-CTAL-TA-Sample Exam A Questions-v4.0-EN/sample-exam-questions.html"
Compiled file "/mnt/sample-exam-answers.tex" to "html/ISTQB-CTAL-TA-Sample Exam A Answers-v4.0-EN/sample-exam-answers.html"
```
```
root@c7df818d3e71:/mnt# istqb-template compile-tex-to-epub epub
Compiled file "/mnt/sample-exam-questions.tex" to "/mnt/epub/ISTQB-CTAL-TA-Sample Exam A Questions-v4.0-EN.epub"
Compiled file "/mnt/sample-exam-answers.tex" to "/mnt/epub/ISTQB-CTAL-TA-Sample Exam A Answers-v4.0-EN.epub"
```

This PR also makes the following changes:

- Determine project name statically from `template.py`, not dynamically from TeX code.
  This allows us to use it even for DOCX output, where TeX is never used.
- Add missing dependencies and fix typos in code.

This PR closes #91.