### PR TITLE
Prevent a TypeError when `HEAD` is detached and do not run CI when a tag has been created

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,6 +12,10 @@ on:
         default: false
         type: boolean
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 permissions:
   contents: write
 env:

--- a/template.py
+++ b/template.py
@@ -490,8 +490,11 @@ def _changed_paths(base_branch='origin/main') -> List[Path]:
 def _should_do_full_compile() -> bool:
     if CURRENT_REPOSITORY is None:
         return False
-    branch_name = CURRENT_REPOSITORY.active_branch.name
-    return branch_name == 'main'
+    try:
+        branch_name = CURRENT_REPOSITORY.active_branch.name
+        return branch_name == 'main'
+    except TypeError:  # if HEAD is detached
+        return False
 
 
 @contextmanager


### PR DESCRIPTION
This PR makes the following changes:

- Prevent a TypeError when `HEAD` is detached.
- Do not run CI when a tag has been created.
  See also the following commits:
    - https://github.com/istqborg/istqb-ctal-ta/commit/68ab97c54748b4b76be6f7ebf82c38b53bf4a260 and https://github.com/istqborg/istqb-ctal-ta/commit/aa834e2ac41c9d29b2356ec7c1002dab5dc572ee from CTAL-TA
    - https://github.com/istqborg/istqb-ct-qdo/commit/ece33cd2479f665089f2437dd0572327bad9505b and https://github.com/istqborg/istqb-ct-qdo/commit/4d80768aa57250011ee920449d747d67dc191eda from CT-QDO
    - https://github.com/istqborg/istqb-ctfl/commit/89485f8fa24ca3e9f3725e4f8decd635db8dc37d and https://github.com/istqborg/istqb-ctfl/commit/20efcadb0d68cea2c6cd06385a7f6cc1e1f356cb from CTFL
    - https://github.com/istqborg/istqb_product_template/commit/7c9a2bfe76841c9d144175e8290b41a888c07d04 and https://github.com/istqborg/istqb_product_template/commit/bb044c90100fb772b39fead5c53ccf23dd78292a from the template
    - https://github.com/istqborg/istqb-ct-tae/commit/b6ef545880c8aae9de9e143549f2720afbb785c4 and https://github.com/istqborg/istqb-ct-tae/commit/444eddafc829e7659ef75d6942530658dc359b3a from CT-TAE
    - https://github.com/istqborg/istqb-ct-tas/commit/5f9ea8060250bde35e27c9c8dde4b8853f56bca4 and https://github.com/istqborg/istqb-ct-tas/commit/38bf6999c94738366418ec0ca36ef355d9092a3c from CT-TAS
    - https://github.com/istqborg/istqb_shared_documents/commit/eb6a983378650ab85fd12193401ae7f5caf875a0 and https://github.com/istqborg/istqb_shared_documents/commit/f54f6345dc7e8387cb274ebbd2778f16816e4b1f from shared documents
    - https://github.com/istqborg/istqb-ct-atlas/commit/af532ae07be7ef2f2c859f561b4751eda147c945 and https://github.com/istqborg/istqb-ct-atlas/commit/29408e5499a91c6c52adf2e32a4d15556494eaf3 from CT-ATLAS

This PR closes #93.