### PR TITLE
Fix borders for section headings and tables, reduce table cell margins

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -16,6 +16,7 @@ makeindex
 mdframed
 needspace
 newunicodechar
+nicematrix
 supertabular
 tex-gyre
 titlesec

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -669,7 +669,8 @@
   { istqbtable }
   [ 1 ]
   {
-    \renewcommand { \arraystretch }{ 1.5 }  % Increase line spread
+    \renewcommand { \arraystretch }{ 1.25 }  % Set vertical cell margins
+    \setlength \tabcolsep { 3pt }  % Set horizontal cell margins
     \str_if_in:nnTF
       { #1 }
       { X }

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -661,7 +661,7 @@
 \RequirePackage{hyperref}
 
 % Tables
-\RequirePackage{tabularx, array}
+\RequirePackage{nicematrix, tabularx}
 \RequirePackage{xcolor, colortbl}
 \definecolor{istqbtableheader}{HTML}{D9D9D9}
 \ExplSyntaxOn
@@ -670,38 +670,35 @@
   [ 1 ]
   {
     \renewcommand { \arraystretch }{ 1.5 }  % Increase line spread
-    \rowcolors { 2 } { white } { white }  % Ensure white rows below table head
     \str_if_in:nnTF
       { #1 }
       { X }
       {
         \cs_set:Npn
           \endistqbtable
-          { \endtabularx }
-        \tabularx \linewidth { #1 } \hline
+	  { \end { NiceTabularX } }
+        \begin { NiceTabularX } \linewidth { #1 } \hline
       }
       {
         \cs_set:Npn
           \endistqbtable
           {
-            \end { tabular }
+            \end { NiceTabular }
             \par
           }
         \centering
-        \begin { tabular } { #1 } \hline
+        \begin { NiceTabular } { #1 } \hline
       }
-    \rowcolor { istqbtableheader }  % Color table head
+    \RowStyle [ nb-rows=1, rowcolor=istqbtableheader ] { }  % Color table head
   }
   { }
 \ExplSyntaxOff
 
 %% Revision History
 \newenvironment{istqbrevisionhistory}{%
-  \renewcommand{\arraystretch}{1.5}% Increase line spread
-  \tabularx{\linewidth}{|l|l|X|}\hline
-  \rowcolor{istqbtableheader}%
+  \begin{istqbtable}{|l|l|X|}%
 }{%
-  \endtabularx
+  \end{istqbtable}%
 }
 
 % Table of Contents

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -167,6 +167,7 @@
 %%% Footer
 \renewcommand{\footrulewidth}{0pt}
 \RequirePackage{xcolor}
+\PassOptionsToPackage{framemethod=tikz}{mdframed}
 \RequirePackage{mdframed}
 \@ifundefined
   {HCode}%


### PR DESCRIPTION
This PR makes the following changes:

- Fix borders for section headings and tables.
  See a before-and-after example of question 14 from the CTAL-TA Sample Exam Questions A document in Adobe Reader:
  ![image](https://github.com/user-attachments/assets/f206650e-542b-4a66-9ec5-40fee8bfa632)
- Slightly reduce table cell margins, as requested by @danopolan in [\#69](https://github.com/istqborg/istqb_product_base/issues/69#issue-2345668683).
  See a before-and-after example of question 14 from the CTAL-TA Sample Exam Questions A document in Adobe Reader:
  ![image](https://github.com/user-attachments/assets/2c21409e-9553-4ae5-a795-eab7ebed66e1)

This PR closes #69.