### PR TITLE
Start on page 2 after the landing page

### DIFF
--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -200,7 +200,7 @@
       \centering
       \int_set:Nn
         \l_tmpa_int
-        { \thepage - 1 }
+        { \thepage }
       \str_if_eq:VnTF
         \lastpage@lastpage
         { ?? }
@@ -212,7 +212,7 @@
         {
           \int_set:Nn
             \l_tmpb_int
-            { \lastpage@lastpage - 1 }
+            { \lastpage@lastpage }
         }
       \mbox
         {


### PR DESCRIPTION
This PR shifts the pagination, so that it agrees with the page numbers in the PDF viewer.

For example, here is how the first two pages of the example document look after this PR:

![image](https://github.com/user-attachments/assets/2b2388da-40a8-4dfa-a8ba-0c6af951bb7f)

This PR closes #99.

