### PR TITLE
Validate LaTeX and Markdown files

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -43,6 +43,7 @@ jobs:
           git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
           cd /opt/istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
+          pip install -r requirements.txt --break-system-packages
       - name: Validate LaTeX documents
         run: istqb-template validate-files tex
       - name: Validate MD documents
@@ -73,6 +74,7 @@ jobs:
           git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
           cd /opt/istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
+          pip install -r requirements.txt --break-system-packages
           retry -t 30 -d 60 tlmgr install $(sort -u DEPENDS.txt)
       - name: Compile LaTeX documents to PDF
         run: istqb-template compile-tex-to-pdf
@@ -105,6 +107,7 @@ jobs:
           git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
           cd /opt/istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
+          pip install -r requirements.txt --break-system-packages
           retry -t 30 -d 60 tlmgr install $(sort -u DEPENDS.txt)
       - name: Compile LaTeX documents to HTML
         run: istqb-template compile-tex-to-html html/
@@ -137,6 +140,7 @@ jobs:
           git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
           cd /opt/istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
+          pip install -r requirements.txt --break-system-packages
           retry -t 30 -d 60 tlmgr install $(sort -u DEPENDS.txt)
       - name: Compile LaTeX documents to EPUB
         run: istqb-template compile-tex-to-epub epub/
@@ -169,6 +173,7 @@ jobs:
           git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
           cd /opt/istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
+          pip install -r requirements.txt --break-system-packages
       - name: Convert documents to DOCX
         run: istqb-template compile-tex-to-docx docx/
       - name: Upload DOCX documents

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -43,8 +43,12 @@ jobs:
           git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
           cd /opt/istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
-      - name: Validate LaTeX, MD, and YAML documents
-        run: istqb-template validate-files all
+      - name: Validate LaTeX documents
+        run: istqb-template validate-files tex
+      - name: Validate MD documents
+        run: istqb-template validate-files markdown
+      - name: Validate YAML documents
+        run: istqb-template validate-files all-yaml
   produce-pdf:
     name: Produce PDF documents
     needs:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -22,7 +22,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
   validate:
-    name: Validate YAML documents
+    name: Validate LaTeX, MD, and YAML documents
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/istqborg/istqb_product_base:latest
@@ -43,8 +43,8 @@ jobs:
           git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
           cd /opt/istqb_product_base
           git checkout ${{ inputs.base-version || github.sha }}
-      - name: Validate YAML documents
-        run: istqb-template validate-files all-yaml
+      - name: Validate LaTeX, MD, and YAML documents
+        run: istqb-template validate-files all
   produce-pdf:
     name: Produce PDF documents
     needs:

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -16,6 +16,7 @@ luaxml
 make4ht
 makeindex
 mdframed
+mwe
 needspace
 newunicodechar
 nicematrix

--- a/example-document/03-troubleshooting.md
+++ b/example-document/03-troubleshooting.md
@@ -50,7 +50,7 @@ Reference `section:explain-which-factors-support-and-affect-tas-maintainability'
 Example of the log:
 
 1. Make sure your section identifier `{#apply-layering-of-taf}` is existent within your MD files. See <#section:section-references> for more details.
-2. Make sure you are using the reference in text like `<#section:#apply-layering-of-taf>` correctly. Typos are common here. See <#section:section-references> for more details.
+2. Make sure you are using the reference in text like `<#section:apply-layering-of-taf>` correctly. Typos are common here. See <#section:section-references> for more details.
 3. Make sure, all Markdown files you are referencing to are part of the `.tex` file, so they are included in a final rendered file. See <#section:architecture-of-the-solution> for mode details.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 GitPython==3.1.43
 PyYAML==6.0.1
-thefuzz==0.22.1
+rapidfuzz==3.9.7
 yamale==4.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 GitPython==3.1.43
 PyYAML==6.0.1
+thefuzz==0.22.1
 yamale==4.0.4

--- a/template.py
+++ b/template.py
@@ -114,7 +114,7 @@ FileLocation = Tuple[Path, int]
 
 
 def _get_nearest_text(text: str, texts: Iterable[str]) -> str:
-    from rapidfuzz import process, fuzz, utils
+    from rapidfuzz import process, utils
     nearest_text, *_ = process.extractOne(text, texts, processor=utils.default_process)
     return nearest_text
 

--- a/template.py
+++ b/template.py
@@ -424,7 +424,11 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                 all_filenames = [str(path) for path in _find_files(['all'])]
                 if all_filenames:
                     nearest_filename = _get_nearest_text(str(original_referenced_path), all_filenames)
-                    nearest_path = Path(nearest_filename).relative_to(tex_input_path.parent, walk_up=True)
+                    nearest_path = Path(nearest_filename)
+                    try:
+                        nearest_path = nearest_path.relative_to(tex_input_path.parent)
+                    except ValueError:
+                        pass
                     message = f'{message}; did you mean "{nearest_path}"?'
                 raise ValueError(message)
 

--- a/template.py
+++ b/template.py
@@ -420,7 +420,13 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
         for (tex_input_path, character_number), original_referenced_path, referenced_paths in references:
             line_number = _get_line_number_from_file_location((tex_input_path, character_number))
             if not any(path.exists() for path in referenced_paths):
-                raise ValueError(f'File "{original_referenced_path}" referenced on line {line_number} of file "{tex_input_path}" not found')
+                message = f'File "{original_referenced_path}" referenced on line {line_number} of file "{tex_input_path}" not found'
+                all_filenames = [str(path) for path in _find_files(['all'])]
+                if all_filenames:
+                    nearest_filename = _get_nearest_text(str(original_referenced_path), all_filenames)
+                    message = f'{message}; did you mean "{nearest_filename}"?'
+                raise ValueError(message)
+
         if not silent:
             LOGGER.info('Validated file "%s" that references %d other files', path, len(references))
 

--- a/template.py
+++ b/template.py
@@ -491,10 +491,15 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                     (second_md_input_path, second_character_number) = md_identifiers[md_identifier]
                 first_line_number = _get_line_number_from_file_location((first_md_input_path, first_character_number))
                 second_line_number = _get_line_number_from_file_location((second_md_input_path, second_character_number))
-                raise ValueError(
+                message = (
                     f'Markdown identifier "{md_identifier}" is defined twice, once on line {first_line_number} of file '
-                    f'"{first_md_input_path}" and once on line {second_line_number} of file "{second_md_input_path}"'
+                    f'"{first_md_input_path}" and once on line {second_line_number}'
                 )
+                if first_md_input_path == second_md_input_path:
+                    message = f'{message} of the same file'
+                else:
+                    message = f'{message} of file "{second_md_input_path}"'
+                raise ValueError(message)
         bib_input_paths = list(_find_files(file_types=['bib'], tex_input_paths=[tex_input_path]))
         for location, bib_identifier in _get_identifiers_from_bib_files(bib_input_paths):
             bib_identifiers[bib_identifier].append(location)
@@ -503,10 +508,15 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                     (second_bib_input_path, second_character_number) = bib_identifiers[bib_identifier]
                 first_line_number = _get_line_number_from_file_location((first_bib_input_path, first_character_number))
                 second_line_number = _get_line_number_from_file_location((second_bib_input_path, second_character_number))
-                raise ValueError(
+                message = (
                     f'BIB identifier "{bib_identifier}" is defined twice, once on line {first_line_number} of file '
-                    f'"{first_bib_input_path}" and once on line {second_line_number} of file "{second_bib_input_path}"'
+                    f'"{first_bib_input_path}" and once on line {second_line_number}'
                 )
+                if first_bib_input_path == second_bib_input_path:
+                    message = f'{message} of the same file'
+                else:
+                    message = f'{message} of file "{second_bib_input_path}"'
+                raise ValueError(message)
 
         for location, md_identifier in _get_cross_references_from_markdown_files([path]):
             cross_references[md_identifier].append(location)

--- a/template.py
+++ b/template.py
@@ -130,7 +130,7 @@ def _get_references_from_tex_files(tex_input_paths: Iterable[Path]) -> Iterable[
                     referenced_paths = [referenced_path]
                     # For YAML questions, yield also MD question source files.
                     if QUESTIONS_YAML_REGEXP.fullmatch(referenced_path.name):
-                        for referenced_md_path in path.parent.glob(f'{path.stem}.*'):
+                        for referenced_md_path in referenced_path.parent.glob(f'{referenced_path.stem}.*'):
                             if QUESTIONS_MARKDOWN_REGEXP.fullmatch(referenced_md_path.name):
                                 referenced_md_path = referenced_md_path.resolve()
                                 referenced_paths.append(referenced_md_path)

--- a/template.py
+++ b/template.py
@@ -24,7 +24,6 @@ import os
 import shutil
 
 from git import Repo, InvalidGitRepositoryError
-from thefuzz import process
 import yamale
 import yaml
 
@@ -115,7 +114,8 @@ FileLocation = Tuple[Path, int]
 
 
 def _get_nearest_text(text: str, texts: Iterable[str]) -> str:
-    nearest_text, _ = process.extractOne(text, texts)
+    from rapidfuzz import process, fuzz, utils
+    nearest_text, *_ = process.extractOne(text, texts, processor=utils.default_process)
     return nearest_text
 
 

--- a/template.py
+++ b/template.py
@@ -557,9 +557,14 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                 validate_tex_file(path)
         if file_type in ('markdown', 'all'):
             for tex_input_path in _find_files(file_types=['tex']):
+                md_input_paths = list(_find_files(file_types=['markdown'], tex_input_paths=[tex_input_path]))
                 if tex_input_path == EXAMPLE_DOCUMENT:
+                    LOGGER.info(
+                        'Skipping the validation of %d markdown documents referenced from example document "%s"',
+                        len(md_input_paths), tex_input_path,
+                    )
                     continue
-                for md_input_path in _find_files(file_types=['markdown'], tex_input_paths=[tex_input_path]):
+                for md_input_path in md_input_paths:
                     validate_markdown_file(md_input_path, tex_input_path)
 
 

--- a/template.py
+++ b/template.py
@@ -436,7 +436,6 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                 message = f'{message}; did you mean "{nearest_identifier}" defined on line {line_number} of file "{md_input_path}"?'
             raise ValueError(message)
 
-
         unused_identifiers = identifiers.keys() - cross_references.keys()
         for unused_identifier in unused_identifiers:
             (md_input_path, character_number), *_ = identifiers[unused_identifier]

--- a/template.py
+++ b/template.py
@@ -83,7 +83,7 @@ CROSS_REFERENCE_REGEXP = re.compile(
         r']\(#(.+?)\)',  # Relative direct link
     ])
 )
-BIBLIOGRAPHIC_REFERENCE_REGEXP = re.compile(r'@([-a-zA-Z0-9#$%&+<>~/_]+)')  # Bracketed and text citations
+BIBLIOGRAPHIC_REFERENCE_REGEXP = re.compile(r'(?<![a-zA-Z0-9])@([-a-zA-Z0-9#$%&+<>~/_:.?]+)')  # Bracketed and text citations
 BIBENTRY_REGEXP = re.compile(r'^\s*@[^{]+\{(.+?)\s*,\s*$', re.MULTILINE)
 IDENTIFIER_REGEXP = re.compile(r'#(?P<identifier>\S+)')
 
@@ -203,7 +203,7 @@ def _get_bibliographic_references_from_markdown_file(md_input_path: Path) -> Lis
         text = f.read()
         for identifier_match in BIBLIOGRAPHIC_REFERENCE_REGEXP.finditer(text):
             group_number, = [group_number + 1 for group_number, group in enumerate(identifier_match.groups()) if group is not None]
-            identifier = identifier_match.group(group_number)
+            identifier = identifier_match.group(group_number).rstrip(':.?')
             character_number = identifier_match.start(group_number)
             result = (md_input_path, character_number), identifier
             results.append(result)

--- a/template.py
+++ b/template.py
@@ -519,30 +519,40 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
         for missing_md_identifier in missing_md_identifiers:
             (md_input_path, character_number), *_ = cross_references[missing_md_identifier]
             line_number = _get_line_number_from_file_location((md_input_path, character_number))
-            message = (
-                f'Markdown identifier "{missing_md_identifier}" referenced on line {line_number} of file "{md_input_path}" not found '
-                f'in any of the {len(md_input_paths)} markdown files referenced from file "{tex_input_path}"'
-            )
+            message = f'Markdown identifier "{missing_md_identifier}" referenced on line {line_number} of file "{md_input_path}" not found'
+            if len(md_input_paths) == 1:
+                message = f'{message} in file "{md_input_paths[0]}"'
+            else:
+                message = f'{message} in any of the {len(md_input_paths)} markdown files referenced from file "{tex_input_path}"'
             if md_identifiers:
                 nearest_md_identifier = _get_nearest_text(missing_md_identifier, md_identifiers.keys())
                 (md_input_path, character_number), *_ = md_identifiers[nearest_md_identifier]
                 line_number = _get_line_number_from_file_location((md_input_path, character_number))
-                message = f'{message}; did you mean "{nearest_md_identifier}" defined on line {line_number} of file "{md_input_path}"?'
+                message = f'{message}; did you mean "{nearest_md_identifier}" defined on line {line_number} of'
+                if len(md_input_paths) == 1:
+                    message = f'{message} the same file?'
+                else:
+                    message = f'{message} file "{md_input_path}"?'
             raise ValueError(message)
 
         missing_bib_identifiers = bibliographic_references.keys() - bib_identifiers.keys() - BUILTIN_IDENTIFIERS
         for missing_bib_identifier in missing_bib_identifiers:
             (md_input_path, character_number), *_ = bibliographic_references[missing_bib_identifier]
             line_number = _get_line_number_from_file_location((md_input_path, character_number))
-            message = (
-                f'BIB identifier "{missing_bib_identifier}" referenced on line {line_number} of file "{md_input_path}" not found '
-                f'in any of the {len(bib_input_paths)} BIB files referenced from file "{tex_input_path}"'
-            )
+            message = f'BIB identifier "{missing_bib_identifier}" referenced on line {line_number} of file "{md_input_path}" not found'
+            if len(bib_input_paths) == 1:
+                message = f'{message} in file "{bib_input_paths[0]}"'
+            else:
+                message = f'{message} in any of the {len(bib_input_paths)} BIB files referenced from file "{tex_input_path}"'
             if bib_identifiers:
                 nearest_bib_identifier = _get_nearest_text(missing_bib_identifier, bib_identifiers.keys())
                 (bib_input_path, character_number), *_ = bib_identifiers[nearest_bib_identifier]
                 line_number = _get_line_number_from_file_location((bib_input_path, character_number))
-                message = f'{message}; did you mean "{nearest_bib_identifier}" defined on line {line_number} of file "{bib_input_path}"?'
+                message = f'{message}; did you mean "{nearest_bib_identifier}" defined on line {line_number} of'
+                if len(bib_input_paths) == 1:
+                    message = f'{message} the same file?'
+                else:
+                    message = f'{message} file "{bib_input_path}"?'
             raise ValueError(message)
 
         unused_md_identifiers = md_identifiers.keys() - cross_references.keys()
@@ -550,26 +560,24 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
             (md_input_path, character_number), *_ = md_identifiers[unused_md_identifier]
             line_number = _get_line_number_from_file_location((md_input_path, character_number))
             if not silent:
-                _warning(
-                    (
-                        'Markdown identifier "%s" defined on line %d of file "%s" is unused in any of the %d markdown files referenced '
-                        'from file "%s"'
-                    ),
-                    unused_md_identifier, line_number, md_input_path, len(md_input_paths), tex_input_path,
-                )
+                message = f'Markdown identifier "{unused_md_identifier}" defined on line {line_number} of file "{md_input_path}" is unused'
+                if len(md_input_paths) == 1:
+                    message = f'{message} in file "{md_input_paths[0]}"'
+                else:
+                    message = f'{message} in any of the {len(md_input_paths)} markdown files referenced from file "{tex_input_path}"'
+                _warning(message)
 
         unused_bib_identifiers = bib_identifiers.keys() - bibliographic_references.keys()
         for unused_bib_identifier in unused_bib_identifiers:
             (bib_input_path, character_number), *_ = bib_identifiers[unused_bib_identifier]
             line_number = _get_line_number_from_file_location((bib_input_path, character_number))
             if not silent:
-                _warning(
-                    (
-                        'BIB identifier "%s" defined on line %d of file "%s" is unused in any of the %d markdown files referenced '
-                        'from file "%s"'
-                    ),
-                    unused_bib_identifier, line_number, bib_input_path, len(md_input_paths), tex_input_path,
-                )
+                message = f'BIB identifier "{unused_bib_identifier}" defined on line {line_number} of file "{bib_input_path}" is unused'
+                if len(md_input_paths) == 1:
+                    message = f'{message} in file "{md_input_paths[0]}"'
+                else:
+                    message = f'{message} in any of the {len(md_input_paths)} markdown files referenced from file "{tex_input_path}"'
+                _warning(message)
 
         if not silent:
             LOGGER.info(

--- a/template.py
+++ b/template.py
@@ -424,7 +424,8 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                 all_filenames = [str(path) for path in _find_files(['all'])]
                 if all_filenames:
                     nearest_filename = _get_nearest_text(str(original_referenced_path), all_filenames)
-                    message = f'{message}; did you mean "{nearest_filename}"?'
+                    nearest_path = Path(nearest_filename).relative_to(tex_input_path.parent, walk_up=True)
+                    message = f'{message}; did you mean "{nearest_path}"?'
                 raise ValueError(message)
 
         if not silent:

--- a/template.py
+++ b/template.py
@@ -384,10 +384,11 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                     unused_identifier, line_number, md_input_path, len(md_input_paths), tex_input_path,
                 )
 
-        LOGGER.info(
-            'Validated file "%s" that contains %d identifiers and %d cross-references',
-            path, len(identifiers), num_cross_references,
-        )
+        if not silent:
+            LOGGER.info(
+                'Validated file "%s" that contains %d identifiers and %d cross-references',
+                path, len(identifiers), num_cross_references,
+            )
 
     for file_type in file_types:
         if file_type in ('metadata', 'all', 'all-yaml'):

--- a/template.py
+++ b/template.py
@@ -341,10 +341,6 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
         if not silent:
             LOGGER.info('Validated file "%s" that references %d other files', path, len(references))
 
-        if file_type in ('markdown', 'all'):
-            for md_input_path in _find_files(file_types=['markdown'], tex_input_paths=[path]):
-                validate_markdown_file(md_input_path, path)
-
     def validate_markdown_file(path: Path, tex_input_path: Path):
         # Check cross-references.
         identifiers: Dict[str, List[Tuple[Path, int]]] = defaultdict(lambda: list())

--- a/template.py
+++ b/template.py
@@ -378,7 +378,7 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
             if not silent:
                 LOGGER.warning(
                     (
-                        'Identifier "%s" referenced on line %d of file "%s" is unused in any of the %d markdown files referenced '
+                        'Identifier "%s" defined on line %d of file "%s" is unused in any of the %d markdown files referenced '
                         'from file "%s"'
                     ),
                     unused_identifier, line_number, md_input_path, len(md_input_paths), tex_input_path,

--- a/template.py
+++ b/template.py
@@ -479,6 +479,8 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
                 validate_tex_file(path)
         if file_type in ('markdown', 'all'):
             for tex_input_path in _find_files(file_types=['tex']):
+                if tex_input_path == EXAMPLE_DOCUMENT:
+                    continue
                 for md_input_path in _find_files(file_types=['markdown'], tex_input_paths=[tex_input_path]):
                     validate_markdown_file(md_input_path, tex_input_path)
 


### PR DESCRIPTION
This PR adds validation of the following conditions to the continuous integration:

- [x] A LaTeX file references a nonexistent MD, YAML, or BIB file.
- [x] An MD file cross-references an undefined identifier from the same or some other MD file.
- [x] An MD file cites an undefined bibliographic reference from a BIB file.

See also the discussion in https://github.com/istqborg/istqb_shared_documents/issues/65#issuecomment-2305816568.

Furthermore, this PR also makes the continuous integration produce warnings about unused cross-references and bibliographic references during validation.