### PR TITLE
Add support for variables in markdown text

### DIFF
--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -217,6 +217,23 @@ So it will produce the following output:
 		1. And second level nested item	(using 2x tab)
 1. And so on, until you have them all here
 
+## Variables
+
+You can use metadata from file `metadata.yml` by writing `\${metadata.title}`. This will produce the following output: ${metadata.title}.
+
+You can also define your own variables in section `variables` of the file `metadata.yml` as follows:
+
+```yaml
+# User-defined variables
+variables:
+  foo: bar
+  bar: baz
+```
+
+Then, you can use your variables by writing `\${metadata.variables.foo}`. This will produce the following output: ${metadata.variables.foo}.
+
+Sometimes, you may want to write something that looks like a metadata field or like a variable. You can achieve this by writing a backslash (`\`) before the dollar sign (`$`). For example, you can write `\\\${metadata.variables.bar}`. This will produce the following output: \${metadata.variables.bar}.
+
 ## Sections {.landscape}
 
 You can write the heading of a second-level section as follows:

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -23,3 +23,7 @@ provided-by:
 # 3rd-party organizations without logos
 - name: International Requirements Engineering Board  # or just:
 - Hungarian Testing Board
+# User-defined variables
+variables:
+  foo: bar
+  bar: baz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 GitPython==3.1.43
 PyYAML==6.0.1
 rapidfuzz==3.9.7
-regex==2024.9.11
 yamale==4.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 GitPython==3.1.43
 PyYAML==6.0.1
 rapidfuzz==3.9.7
+regex==2024.9.11
 yamale==4.0.4

--- a/schema/metadata.yml
+++ b/schema/metadata.yml
@@ -17,6 +17,7 @@ pdf-output: bool(required=False)
 docx-output: bool(required=False)
 epub-output: bool(required=False)
 html-output: bool(required=False)
+variables: map(str(), key=str(), required=False)
 ---
 third-parties: list(any(str(), include('third-party')))
 ---

--- a/template.py
+++ b/template.py
@@ -161,11 +161,11 @@ def _replace_variables_for_single_tex_file(input_paths: Iterable[Path], tex_inpu
                 if variable_name not in variables:
                     character_number = match.start('variable_name')
                     line_number = _get_line_number_from_file_location((input_path, character_number))
-                    message = f'Variable "{variable_name}" referenced on line {line_number} of file "{input_path}" not found'
+                    message = f'Variable "${{{variable_name}}}" referenced on line {line_number} of file "{input_path}" not found'
                     if variables:
                         nearest_variable_name = _get_nearest_text(variable_name, variables.keys())
                         metadata_path, _ = variables[nearest_variable_name]
-                        message = f'{message}; did you mean "{nearest_variable_name}" defined in file "{metadata_path}"?'
+                        message = f'{message}; did you mean "${{{nearest_variable_name}}}" defined in file "{metadata_path}"?'
                     raise ValueError(message)
                 else:
                     metadata_path, variable_value = variables[variable_name]

--- a/template.py
+++ b/template.py
@@ -152,6 +152,7 @@ def _replace_variables_for_single_tex_file(input_paths: Iterable[Path], tex_inpu
                                 )
                             else:
                                 variables[key] = (metadata_path, value)
+
             # Replace variables in the original content.
             def replace_variable(match):
                 variable_name = match.group('variable_name')

--- a/template.py
+++ b/template.py
@@ -20,10 +20,10 @@ import subprocess
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, TYPE_CHECKING
 import os
+import re
 import shutil
 
 from git import Repo, InvalidGitRepositoryError
-import regex as re
 import yamale
 import yaml
 

--- a/template.py
+++ b/template.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import string
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, TYPE_CHECKING
 import os
 import re
 import shutil
@@ -201,8 +201,6 @@ def _replace_variables_for_many_tex_files(tex_input_paths: Iterable[Path], dry_r
         input_paths = list(_find_files(file_types=['markdown'], tex_input_paths=[tex_input_path]))
         for input_path in input_paths:
             # Detect ambiguous replacements of unescaped variables.
-            with input_path.open('rt') as f:
-                text = f.read()
             with _replace_variables_for_single_tex_file([input_path], tex_input_path, dry_run=True) as variable_replacements:
                 variable_replacements_tuple = tuple(sorted(variable_replacements.items()))
                 simple_variable_replacements_tuple = tuple(sorted(

--- a/template.py
+++ b/template.py
@@ -8,14 +8,13 @@ Processes ISTQB documents written with the LaTeX+Markdown template.
 from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from configparser import ConfigParser
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 from itertools import chain, repeat
 from functools import lru_cache
 import json
 import logging
 from multiprocessing import Pool
 from pathlib import Path
-import re
 import string
 import subprocess
 from tempfile import NamedTemporaryFile
@@ -24,6 +23,7 @@ import os
 import shutil
 
 from git import Repo, InvalidGitRepositoryError
+import regex as re
 import yamale
 import yaml
 
@@ -109,8 +109,102 @@ QUESTIONS_ANSWER_REGEXP = re.compile(
 )
 QUESTIONS_EXPLANATION_REGEXP = re.compile(r'\s{0,3}##\s*(explanation|justification)\s*', flags=re.IGNORECASE)
 
+VARIABLE_PREFIX, VARIABLE_SUFFIX = r'(?<=(?:^|[^\\])(?:\\\\)*)', r'\$\{(?P<variable_name>[^}]+)\}'
+VARIABLE_REGEXP = re.compile(f'{VARIABLE_PREFIX}{VARIABLE_SUFFIX}')
+ESCAPED_VARIABLE_REGEXP = re.compile(f'{VARIABLE_PREFIX}\\\\{VARIABLE_SUFFIX}')
+
 
 FileLocation = Tuple[Path, int]
+
+
+@contextmanager
+def _replace_variables_for_single_tex_file(input_paths: Iterable[Path], tex_input_path: Path, dry_run=False):
+    input_paths = list(input_paths)
+    backups = {}
+    try:
+        for input_path in input_paths:
+            # Extract the original content.
+            with input_path.open('rb') as f:
+                original_content = f.read()
+            if not dry_run:
+                backups[input_path] = original_content
+            text = original_content.decode()
+            # Extract all available variables.
+            variables: Dict[str, Tuple[Path, str]] = dict()
+            metadata_paths = _find_files(file_types=['metadata'], tex_input_paths=[tex_input_path])
+            for metadata_path in metadata_paths:
+                with metadata_path.open('rt') as f:
+                    metadata_text = f.read()
+                metadata = yaml.safe_load(metadata_text)
+                sources = {
+                    'metadata': metadata,
+                    'metadata.variables': metadata.get('variables', dict()),
+                }
+                for source_prefix, source_dict in sources.items():
+                    for key, value in source_dict.items():
+                        if isinstance(key, str) and isinstance(value, str):
+                            key = f'{source_prefix}.{key}'
+                            if key in variables:
+                                previous_metadata_path, _ = variables[key]
+                                raise ValueError(
+                                    f'The variable "{key}" has been defined twice for file "{input_path}": '
+                                    f'Once in file "{previous_metadata_path}" and once in file "{metadata_path}"'
+                                )
+                            else:
+                                variables[key] = (metadata_path, value)
+            # Replace variables in the original content.
+            def replace_variable(match):
+                variable_name = match.group('variable_name')
+                if variable_name not in variables:
+                    character_number = match.start('variable_name')
+                    line_number = _get_line_number_from_file_location((input_path, character_number))
+                    message = f'Variable "{variable_name}" referenced on line {line_number} of file "{input_path}" not found'
+                    if variables:
+                        nearest_variable_name = _get_nearest_text(variable_name, variables.keys())
+                        metadata_path, _ = variables[nearest_variable_name]
+                        message = f'{message}; did you mean "{nearest_variable_name}" defined in file "{metadata_path}"?'
+                    raise ValueError(message)
+                else:
+                    _, variable_value = variables[variable_name]
+                    return variable_value
+
+            replaced_text = VARIABLE_REGEXP.sub(replace_variable, text)  # replace unescaped variables with variable values
+            replaced_text = ESCAPED_VARIABLE_REGEXP.sub(  # unescape escaped variables
+                lambda match: f'${{{match.group("variable_name")}}}', replaced_text)
+            if not dry_run:
+                with input_path.open('wt') as f:
+                    print(replaced_text, file=f)
+        yield
+    finally:
+        # Restore the original content.
+        if not dry_run:
+            for input_path, original_content in backups.items():
+                with input_path.open('wb') as f:
+                    f.write(original_content)
+
+
+@contextmanager
+def _replace_variables_for_many_tex_files(tex_input_paths: Iterable[Path], dry_run=False):
+    with ExitStack() as stack:
+        seen_input_paths: Dict[Path, List[Path]] = defaultdict(lambda: list())
+        for tex_input_path in tex_input_paths:
+            input_paths = list(_find_files(file_types=['markdown'], tex_input_paths=[tex_input_path]))
+            for input_path in input_paths:
+                if len(seen_input_paths[input_path]) == 1:
+                    previous_tex_input_path, = seen_input_paths[input_path]
+                    raise ValueError(
+                        f'File "{input_path}" has been referenced both in file "{previous_tex_input_path}" '
+                        f'and in file "{tex_input_path}", which makes variable replacements ambiguous'
+                    )
+                seen_input_paths[input_path].append(tex_input_path)
+            context_manager = _replace_variables_for_single_tex_file(input_paths, tex_input_path, dry_run=dry_run)
+            stack.enter_context(context_manager)
+        yield
+
+
+def _validate_variables(input_paths: Iterable[Path], tex_input_path: Path) -> None:
+    with _replace_variables_for_single_tex_file(input_paths, tex_input_path, dry_run=True):
+        pass
 
 
 def _get_nearest_text(text: str, texts: Iterable[str]) -> str:
@@ -476,6 +570,9 @@ def _validate_files(file_types: Iterable[str], silent: bool = False) -> None:
             LOGGER.info('Validated file "%s" that references %d other files', path, len(references))
 
     def validate_markdown_file(path: Path, tex_input_path: Path):
+        # Check variables.
+        _validate_variables([path], tex_input_path)
+
         # Check cross-references.
         md_identifiers: Dict[str, List[Tuple[Path, int]]] = defaultdict(lambda: list())
         bib_identifiers: Dict[str, List[Tuple[Path, int]]] = defaultdict(lambda: list())
@@ -1102,33 +1199,34 @@ def _compile_tex_files(compile_fn: 'CompilationFunction', *args, **kwargs) -> No
     if not input_paths:
         return
 
-    os.environ['TEXINPUTS'] = f'.:{ROOT_COPY_DIRECTORY}/template:'
-    try:
+    with _replace_variables_for_many_tex_files(input_paths):
+        os.environ['TEXINPUTS'] = f'.:{ROOT_COPY_DIRECTORY}/template:'
         try:
-            shutil.rmtree(ROOT_COPY_DIRECTORY)
-        except FileNotFoundError:
-            pass
-        shutil.copytree(ROOT_DIRECTORY, ROOT_COPY_DIRECTORY)
+            try:
+                shutil.rmtree(ROOT_COPY_DIRECTORY)
+            except FileNotFoundError:
+                pass
+            shutil.copytree(ROOT_DIRECTORY, ROOT_COPY_DIRECTORY)
 
-        _validate_files(file_types=['all'], silent=True)
-        _fixup_line_endings()
-        _convert_eps_files_to_pdf()
-        _convert_xlsx_files_to_pdf()
+            _validate_files(file_types=['all'], silent=True)
+            _fixup_line_endings()
+            _convert_eps_files_to_pdf()
+            _convert_xlsx_files_to_pdf()
 
-        compile_parameters = zip(repeat(compile_fn), input_paths, repeat(args), repeat(kwargs))
-        with Pool(None) as pool:
-            for input_path, output_path in pool.imap_unordered(_compile_fn, compile_parameters):
-                if output_path is None:
-                    LOGGER.info('Skipped the compilation of file "%s" because it has been disabled', input_path)
-                else:
-                    assert output_path.exists(), f'File "{output_path}" does not exist'
-                    LOGGER.info('Compiled file "%s" to "%s"', input_path, output_path)
-    finally:
-        del os.environ['TEXINPUTS']
-        try:
-            shutil.rmtree(ROOT_COPY_DIRECTORY)
-        except FileNotFoundError:
-            pass
+            compile_parameters = zip(repeat(compile_fn), input_paths, repeat(args), repeat(kwargs))
+            with Pool(None) as pool:
+                for input_path, output_path in pool.imap_unordered(_compile_fn, compile_parameters):
+                    if output_path is None:
+                        LOGGER.info('Skipped the compilation of file "%s" because it has been disabled', input_path)
+                    else:
+                        assert output_path.exists(), f'File "{output_path}" does not exist'
+                        LOGGER.info('Compiled file "%s" to "%s"', input_path, output_path)
+        finally:
+            del os.environ['TEXINPUTS']
+            try:
+                shutil.rmtree(ROOT_COPY_DIRECTORY)
+            except FileNotFoundError:
+                pass
 
 
 def _compile_tex_files_to_pdf(previous_continuous: bool) -> None:

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -236,7 +236,7 @@
           { #1 }
           {
             { provided-by } {
-              % A third-party organization
+              % Third-party organizations
               \markdownSetup {
                 code = \group_begin:,
                 renderers = {
@@ -246,6 +246,27 @@
                   / metadata / provided-by,
                 renderers = {
                   jekyllDataSequenceEnd +=
+                    \group_end:
+                },
+              }
+            }
+          }
+      },
+      jekyllDataMappingBegin = {
+        \str_case:nn
+          { #1 }
+          {
+            { variables } {
+              % User-defined variables
+              \markdownSetup {
+                code = \group_begin:,
+                renderers = {
+                  jekyllDataMappingEnd =
+                },
+                snippet = istqb / common
+                  / metadata / variables,
+                renderers = {
+                  jekyllDataMappingEnd +=
                     \group_end:
                 },
               }
@@ -331,6 +352,14 @@
           }
       },
     }
+  }
+\markdownSetupSnippet
+  { metadata / variables }
+  {
+    renderers = {
+      % Ignore user-defined variables.
+      jekyllData(Typographic|Programmatic)String = ,
+    },
   }
 
 % Traceability matrix


### PR DESCRIPTION
This PR implements and documents support for variables in markdown text:

![image](https://github.com/user-attachments/assets/fd8eaa0f-6365-496e-8a93-175efbc095fd)

This support applies to all output document types such as DOCX:

![image](https://github.com/user-attachments/assets/c876d65c-34e0-41b2-86fe-49decd918a3a)

Mistyping a variable name produces an error during validation. For example:

> Variable "${metadata.variables.boo}" referenced on line 233 of file "/mnt/istqb_product_base/example-document/02-markdown-guidelines.md" not found; did you mean "${metadata.variables.foo}" defined in file "/mnt/istqb_product_base/example-document/metadata.yml"?

### Limitations

The current implementation replaces variables in MD files before compilation and restores them afterwards. For speed purposes, we compile TeX documents in parallel, not sequentially. When an MD file with variables is used from two or more TeX files, then variable replacements could be ambiguous. The current implementation detects the situation when two TeX files reference the same MD file with ambiguous variables and stops the compilation with an error.

For example, I can copy the file `example-document.tex` to `example-document-2.tex` and I can make it use a metadata file `metadata-2.yml` that contains a different value of variable `${metadata.variables.foo}`:

``` diff
  # User-defined variables
  variables:
-   foo: bar
+   foo: baz
```

When I run validation, I will receive the following error:

> File "/mnt/istqb_product_base/example-document/02-markdown-guidelines.md" uses ambiguous variable "${metadata.variables.foo}" and has been referenced in file "/mnt/istqb_product_base/example-document.tex", where the variable has value "bar" defined in file "/mnt/istqb_product_base/example-document/metadata.yml", and in file "/mnt/istqb_product_base/example-document-2.tex", where the variable has value "baz" defined in file "/mnt/istqb_product_base/example-document/metadata-2.yml".

I don't expect this to happen in practice. If it did and we wanted to support such a use case, then we would need to create a separate build directory for each TeX file with its own copy of all MD files and other resources. However, this seems outside the scope of this PR.

Closes #110.