### PR TITLE
Allow the consistent use of answer letters in file `questions.md`

### DIFF
--- a/template.py
+++ b/template.py
@@ -104,7 +104,7 @@ QUESTIONS_METADATA_REGEXP = re.compile(r'\s{0,3}#\s*metadata\s*', flags=re.IGNOR
 QUESTIONS_QUESTION_REGEXP = re.compile(r'\s{0,3}##\s*question\s*', flags=re.IGNORECASE)
 QUESTIONS_ANSWERS_REGEXP = re.compile(r'\s{0,3}##\s*answers\s*', flags=re.IGNORECASE)
 QUESTIONS_ANSWER_REGEXP = re.compile(
-    r'^\s{0,3}(?P<number>[0-9])[.]\s*(?P<text>(.(?!^\s{0,3}[0-9][.]))*)',
+    r'^\s{0,3}(?P<number_or_letter>[a-e1-5])[.)]\s*(?P<text>(.(?!^\s{0,3}[a-e1-5][.)]))*)',
     flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
 )
 QUESTIONS_EXPLANATION_REGEXP = re.compile(r'\s{0,3}##\s*(explanation|justification)\s*', flags=re.IGNORECASE)
@@ -800,6 +800,9 @@ def _read_md_questions(input_file: Path) -> Iterable[Tuple[int, Dict]]:
     section_line_numbers = []
     heading_line_number: Optional[int] = None
 
+    def answer_number_to_letter(number: Union[int, str]) -> str:
+        return {'1': 'a', '2': 'b', '3': 'c', '4': 'd', '5': 'e'}.get(str(number), str(number))
+
     def finish_section():
         assert question is not None
         assert section is not None
@@ -828,8 +831,8 @@ def _read_md_questions(input_file: Path) -> Iterable[Tuple[int, Dict]]:
         elif section == 'answers':
             answers = {}
             for answer_match in QUESTIONS_ANSWER_REGEXP.finditer(section_text):
-                answer_number = int(answer_match.group('number'))
-                answer_letter = string.ascii_lowercase[answer_number-1]
+                answer_number = answer_match.group('number_or_letter')
+                answer_letter = answer_number_to_letter(answer_number)
                 answer_text = answer_match.group('text').strip()
                 answers[answer_letter] = answer_text
             question['answers'] = answers

--- a/template.py
+++ b/template.py
@@ -825,7 +825,7 @@ def _read_md_questions(input_file: Path) -> Iterable[Tuple[int, Dict]]:
             if 'correct' not in input_yaml:
                 raise ValueError(f'Missing YAML key "correct" in file "{input_file}" on lines {line_range}')
 
-            def normalize_correct_answers(correct: Union[List[Union[str, int]], str, int]) -> List[str]:
+            def normalize_correct_answers(correct: Union[List[Union[str, int]], str, int]) -> Union[str, List[str]]:
                 def normalize_correct_answer(correct: Union[str, int]) -> str:
                     if isinstance(correct, str):
                         if correct not in ('a', 'b', 'c', 'd', 'e', '1', '2', '3', '4', '5'):

--- a/template.py
+++ b/template.py
@@ -15,7 +15,6 @@ import json
 import logging
 from multiprocessing import Pool
 from pathlib import Path
-import string
 import subprocess
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, TYPE_CHECKING

--- a/template.py
+++ b/template.py
@@ -792,6 +792,7 @@ def _convert_xlsx_files_to_pdf() -> None:
 def _answer_number_to_letter(number: Union[int, str]) -> str:
     return {'1': 'a', '2': 'b', '3': 'c', '4': 'd', '5': 'e'}.get(str(number), str(number))
 
+
 def _read_md_questions(input_file: Path) -> Iterable[Tuple[int, Dict]]:
     with input_file.open('rt') as f:
         input_md_lines = f.read().splitlines()

--- a/template.py
+++ b/template.py
@@ -889,7 +889,7 @@ def _read_md_questions(input_file: Path) -> Iterable[Tuple[int, Dict]]:
 def _convert_md_questions_to_yaml() -> None:
     for input_path in _find_files(['questions-markdown']):
         output_path = input_path.with_suffix('.yml')
-        if output_path.exists():
+        if output_path.exists() and input_path.stat().st_mtime <= output_path.stat().st_mtime:
             _warning('Skipping creation of existing file "%s"', output_path)
             continue
 
@@ -915,7 +915,7 @@ def _convert_md_questions_to_yaml() -> None:
 def _convert_yaml_questions_to_md() -> None:
     for input_path in _find_files(['questions-yaml']):
         output_path = input_path.with_suffix('.md')
-        if output_path.exists():
+        if output_path.exists() and input_path.stat().st_mtime <= output_path.stat().st_mtime:
             _warning('Skipping creation of existing file "%s"', output_path)
             continue
 

--- a/template/markdownthemeistqb_sample-exam_answers.sty
+++ b/template/markdownthemeistqb_sample-exam_answers.sty
@@ -194,6 +194,20 @@
   { 11.15cm }
 \tl_new:N
   \l_istqb_answers_table_tl
+\cs_gset:Nn
+  \__markdown_latex_fancy_list_item_label:nnn
+  {
+    \__markdown_latex_fancy_list_item_label_number:nn
+      { #1 }
+      { #3 }
+    \str_if_eq:nnTF
+      { #1 } { LowerAlpha }
+      { ) }
+      {
+        \__markdown_latex_fancy_list_item_label_delimiter:n
+          { #2 }
+      }
+  }
 \markdownSetupSnippet
   { answers }
   {


### PR DESCRIPTION
This PR makes the following changes:

- In the `correct:` field from section `# metadata` section of `questions.md`, accept both 1–5 and a–e.
- In the `## answers` section of `questions.md`, accept all `1.`, `a.`, and `a)`.
- In the `## justification` section of `questions.md`, render both `a)` and `a.` as `a)`.
- All output formats have correct formatting with lettered lists.

This PR should be merged before PR https://github.com/istqborg/istqb_product_template/pull/18.

Closes #113.