### PR TITLE
Add translations for the traceability matrix

### DIFF
--- a/languages/cs.yml
+++ b/languages/cs.yml
@@ -35,7 +35,7 @@ sample-exam:
 traceability-matrix:
   section-name: |
     Trasovací matice mezi profesními cíli (Business Outcomes)
-    a`~`{=tex}studijními cíli
+    a`~`{=tex}studijními cíli (Learning Objectives)
   description:
     - Tato sekce uvádí trasovatelnost mezi profesními cíli a`~`{=tex}studijními cíli
     - z`~`{=tex}dokumentu

--- a/languages/cs.yml
+++ b/languages/cs.yml
@@ -32,6 +32,14 @@ sample-exam:
     plural: bodů
   number-of-points: Počet bodů
   explanation: Odůvodnění
+traceability-matrix:
+  section-name: |
+    Trasovací matice mezi profesními cíli (Business Outcomes)
+    a`~`{=tex}studijními cíli
+  description:
+    - Tato sekce uvádí trasovatelnost mezi profesními cíli a`~`{=tex}studijními cíli
+    - z`~`{=tex}dokumentu
+  business-outcomes: Profesní cíle
 page: [Strana, z]
 provided-by: [Poskytl, Poskytli]
 istqb: International Software Testing Qualifications Board

--- a/languages/de.yml
+++ b/languages/de.yml
@@ -26,6 +26,14 @@ sample-exam:
   point: [Punkt, Punkte]
   number-of-points: Punkte`\-`{=tex}anzahl
   explanation: Begründung
+traceability-matrix:
+  section-name: |
+    Verfolgbarkeitsmatrix des geschäftlichen Nutzens (Business
+    Outcomes) mit Lernzielen
+  description:
+    - Dieser Abschnitt listet die Anzahl der Lernziele des vorliegenden Lehrplans auf, die mit dem geschäftlichen Nutzen in Verbindung stehen, sowie die Verfolgbarkeit zwischen dem geschäftlichen Nutzen des Lehrplans und den Lernzielen
+    - des
+  business-outcomes: Geschäftlichen Nutzen
 page: [Seite, von]
 provided-by: [Zur Verfügung gestellt von, Zur Verfügung gestellt von]
 istqb: International Software Testing Qualifications Board

--- a/languages/de.yml
+++ b/languages/de.yml
@@ -29,7 +29,7 @@ sample-exam:
 traceability-matrix:
   section-name: |
     Verfolgbarkeitsmatrix des geschäftlichen Nutzens (Business
-    Outcomes) mit Lernzielen
+    Outcomes) mit Lernzielen (Learning Objectives)
   description:
     - Dieser Abschnitt listet die Anzahl der Lernziele des vorliegenden Lehrplans auf, die mit dem geschäftlichen Nutzen in Verbindung stehen, sowie die Verfolgbarkeit zwischen dem geschäftlichen Nutzen des Lehrplans und den Lernzielen
     - des

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -26,6 +26,13 @@ sample-exam:
   point: [Point, Points]
   number-of-points: Number of Points
   explanation: Explanation / Rationale
+traceability-matrix:
+  section-name: |
+    Business Outcomes traceability matrix with Learning Objectives
+  description:
+    - This section lists the traceability between the Business Outcomes and the Learning Objectives
+    - of
+  business-outcomes: Business Outcomes
 page: [Page, of]
 provided-by: [Provided by, Provided by]
 istqb: International Software Testing Qualifications Board

--- a/languages/sk.yml
+++ b/languages/sk.yml
@@ -32,6 +32,14 @@ sample-exam:
     plural: bodov
   number-of-points: Počet bodov
   explanation: Odôvodnenie
+traceability-matrix:
+  section-name: |
+    Trasovacia matica medzi profesijnými cieľmi (Business Outcomes)
+    a`~`{=tex}študijnými cieľmi
+  description:
+    - Táto sekcia uvádza trasovateľnosť medzi profesijnými cieľmi a`~`{=tex}študijnými cieľmi
+    - z`~`{=tex}dokumentu
+  business-outcomes: Profesijné ciele
 page: [Strana, z]
 provided-by: [Poskytol, Poskytli]
 istqb: International Software Testing Qualifications Board

--- a/languages/sk.yml
+++ b/languages/sk.yml
@@ -35,7 +35,7 @@ sample-exam:
 traceability-matrix:
   section-name: |
     Trasovacia matica medzi profesijnými cieľmi (Business Outcomes)
-    a`~`{=tex}študijnými cieľmi
+    a`~`{=tex}študijnými cieľmi (Learning Objectives)
   description:
     - Táto sekcia uvádza trasovateľnosť medzi profesijnými cieľmi a`~`{=tex}študijnými cieľmi
     - z`~`{=tex}dokumentu

--- a/latexmkrc
+++ b/latexmkrc
@@ -7,3 +7,6 @@ $pdf_mode = 1;
 
 ## Treat warnings as errors
 $warnings_as_errors = 1;
+
+## Allow many compilation runs
+$max_repeat=10;

--- a/schema/language.yml
+++ b/schema/language.yml
@@ -25,6 +25,10 @@ sample-exam:
   point: any(list(str(), min=2, max=2), include('point'))
   number-of-points: str()
   explanation: str()
+traceability-matrix:
+  section-name: str()
+  description: [str(), str()]
+  business-outcomes: str()
 page: [str(), str()]
 provided-by: [str(), str()]
 istqb: str()

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -211,6 +211,30 @@
     figure .tl_gset:N = \figurename,
     table .tl_gset:N = \tablename,
   }
+\tl_new:N
+  \g_istqb_translation_traceability_matrix_section_name_tl
+\tl_new:N
+  \g_istqb_translation_traceability_matrix_business_outcomes_tl
+\keys_define:nn
+  { istqb / language / traceability-matrix }
+  {
+    section-name .tl_gset:N =
+      \g_istqb_translation_traceability_matrix_section_name_tl,
+    business-outcomes .tl_gset:N =
+      \g_istqb_translation_traceability_matrix_business_outcomes_tl,
+  }
+\tl_new:N
+  \g_istqb_translation_traceability_matrix_description_tl
+\tl_new:N
+  \g_istqb_translation_traceability_matrix_description_of_tl
+\keys_define:nn
+  { istqb / language / traceability-matrix / description }
+  {
+    1 .tl_gset:N =
+      \g_istqb_translation_traceability_matrix_description_tl,
+    2 .tl_gset:N =
+      \g_istqb_translation_traceability_matrix_description_of_tl,
+  }
 
 % Metadata
 \tl_new:N
@@ -424,30 +448,42 @@
       jekyllDataEnd = {
         \istqblandscapebegin
         \istqbsection
-          { Business~Outcomes~traceability~matrix~with~Learning~Objectives }
-        This~section~lists~the~traceability~between~the~Business~Outcomes~and~the~Learning~Objectives
-        \tl_if_empty:NTF
-          \g_istqb_level_tl
           {
-            \tl_if_empty:NF
-              \g_istqb_title_tl
-              {
-                {}~of~
-                \tl_use:N
-                  \g_istqb_title_tl
-              }
-          }
-          {
-            {}~of~
             \tl_use:N
+              \g_istqb_translation_traceability_matrix_section_name_tl
+          }
+        \tl_use:N
+          \g_istqb_translation_traceability_matrix_description_tl
+
+        \tl_if_empty:NF
+          \g_istqb_title_tl
+          {
+            {}~
+            \tl_use:N
+              \g_istqb_translation_traceability_matrix_description_of_tl
+            {}~
+            \tl_if_empty:NF
               \g_istqb_level_tl
+              {
+                \tl_use:N
+                  \g_istqb_level_tl
+                {}~
+              }
+            \tl_if_empty:NF
+              \g_istqb_type_tl
+              {
+                \tl_use:N
+                  \g_istqb_type_tl
+                {}~
+              }
             \tl_if_empty:NF
               \g_istqb_title_tl
               {
-                {}~
                 \tl_use:N
                   \g_istqb_title_tl
+                {}~
               }
+            \unskip
           }
         .
       },
@@ -607,41 +643,49 @@
         \tl_put_right:Nn
           \l_istqb_traceability_matrix_body_tl
           { \SetCell [ c = 2 ] { l, bg = istqbbluetableheader } \Large }
-        \tl_set:Nn
+        \tl_set:NV
           \l_tmpa_tl
-          { Business~Outcomes }
-        \tl_if_empty:NTF
-          \g_istqb_level_tl
-          {
-            \tl_if_empty:NF
-              \g_istqb_title_tl
-              {
-                \tl_put_right:Nn
-                  \l_tmpa_tl
-                  { :~ }
-                \tl_put_right:NV
-                  \l_tmpa_tl
-                  \g_istqb_title_tl
-              }
-          }
-          {
-            \tl_put_right:Nn
-              \l_tmpa_tl
-              { :~ }
-            \tl_put_right:NV
-              \l_tmpa_tl
-              \g_istqb_level_tl
-            \tl_if_empty:NF
-              \g_istqb_title_tl
-              {
-                \tl_put_right:Nn
-                  \l_tmpa_tl
-                  { ~ }
-                \tl_put_right:NV
-                  \l_tmpa_tl
-                  \g_istqb_title_tl
-              }
-          }
+          \g_istqb_translation_traceability_matrix_business_outcomes_tl
+        \tl_if_empty:NF
+          \g_istqb_title_tl
+            {
+              \tl_put_right:Nn
+                \l_tmpa_tl
+                { :~ }
+              \tl_if_empty:NF
+                \g_istqb_level_tl
+                {
+                  \tl_put_right:NV
+                    \l_tmpa_tl
+                    \g_istqb_level_tl
+                  \tl_put_right:Nn
+                    \l_tmpa_tl
+                    { ~ }
+                }
+              \tl_if_empty:NF
+                \g_istqb_type_tl
+                {
+                  \tl_put_right:NV
+                    \l_tmpa_tl
+                    \g_istqb_type_tl
+                  \tl_put_right:Nn
+                    \l_tmpa_tl
+                    { ~ }
+                }
+              \tl_if_empty:NF
+                \g_istqb_title_tl
+                {
+                  \tl_put_right:NV
+                    \l_tmpa_tl
+                    \g_istqb_title_tl
+                  \tl_put_right:Nn
+                    \l_tmpa_tl
+                    { ~ }
+                }
+              \tl_put_right:Nn
+                \l_tmpa_tl
+                { \unskip }
+            }
         \tl_put_right:Nx
           \l_istqb_traceability_matrix_body_tl
           { { \tl_use:N \l_tmpa_tl } }


### PR DESCRIPTION
Closes #121.

Below, I show how the traceability matrix in the document `example-document.tex` from this repository looks after this PR in English, German, Czech, and Slovak:

### English
![image](https://github.com/user-attachments/assets/dd9cd4f2-34d2-4751-b141-b4a040d7f7d1)
### German
![image](https://github.com/user-attachments/assets/edb24edd-9326-4624-979d-bafb3dc2efe1)
### Czech
![image](https://github.com/user-attachments/assets/ecca1e82-e57b-43da-9e0c-625aba8e4146)
### Slovak
![image](https://github.com/user-attachments/assets/ceae712a-60f5-4c52-8b2f-d85e4371b6ec)