### PR TITLE
Fix unexpected indents in list-like environments (table of contents, bibliography) soon after a page head

### DIFF
--- a/template.py
+++ b/template.py
@@ -1281,8 +1281,9 @@ def _should_compile_tex_file(input_path: Path) -> bool:
     return bool(referenced_paths & changed_paths)
 
 
-def _compile_tex_files(compile_fn: 'CompilationFunction', *args, **kwargs) -> None:
-    input_paths = list(_find_files(file_types=['tex']))
+def _compile_tex_files(compile_fn: 'CompilationFunction', *args, input_paths: Optional[Iterable[Path]] = None, **kwargs) -> None:
+    if input_paths is None:
+        input_paths = list(_find_files(file_types=['tex']))
     if not _should_do_full_compile():
         removed_indexes = []
         for input_path_index, input_path in enumerate(input_paths):
@@ -1327,23 +1328,23 @@ def _compile_tex_files(compile_fn: 'CompilationFunction', *args, **kwargs) -> No
                 pass
 
 
-def _compile_tex_files_to_pdf(previous_continuous: bool) -> None:
-    _compile_tex_files(_compile_tex_file_to_pdf, previous_continuous)
+def _compile_tex_files_to_pdf(previous_continuous: bool, input_paths: Optional[Iterable[Path]]) -> None:
+    _compile_tex_files(_compile_tex_file_to_pdf, previous_continuous, input_paths=input_paths)
 
 
-def _compile_tex_files_to_html(output_directory: Path) -> None:
+def _compile_tex_files_to_html(output_directory: Path, input_paths: Optional[Iterable[Path]]) -> None:
     output_directory.mkdir(parents=True, exist_ok=True)
-    _compile_tex_files(_compile_tex_file_to_html, output_directory)
+    _compile_tex_files(_compile_tex_file_to_html, output_directory, input_paths=input_paths)
 
 
-def _compile_tex_files_to_epub(output_directory: Path) -> None:
+def _compile_tex_files_to_epub(output_directory: Path, input_paths: Optional[Iterable[Path]]) -> None:
     output_directory.mkdir(parents=True, exist_ok=True)
-    _compile_tex_files(_compile_tex_file_to_epub, output_directory)
+    _compile_tex_files(_compile_tex_file_to_epub, output_directory, input_paths=input_paths)
 
 
-def _compile_tex_files_to_docx(output_directory: Path) -> None:
+def _compile_tex_files_to_docx(output_directory: Path, input_paths: Optional[Iterable[Path]]) -> None:
     output_directory.mkdir(parents=True, exist_ok=True)
-    _compile_tex_files(_compile_tex_file_to_docx, output_directory)
+    _compile_tex_files(_compile_tex_file_to_docx, output_directory, input_paths=input_paths)
 
 
 def find_files(args: Namespace) -> None:
@@ -1383,19 +1384,23 @@ def convert_yaml_questions_to_md(args: Namespace) -> None:
 
 
 def compile_tex_files_to_pdf(args: Namespace) -> None:
-    _compile_tex_files_to_pdf(args.previous_continuous)
+    input_paths = sorted(map(Path, args.filenames)) if args.filenames else None
+    _compile_tex_files_to_pdf(args.previous_continuous, input_paths)
 
 
 def compile_tex_files_to_html(args: Namespace) -> None:
-    _compile_tex_files_to_html(output_directory=Path(args.outputdir))
+    input_paths = sorted(map(Path, args.filenames)) if args.filenames else None
+    _compile_tex_files_to_html(Path(args.outputdir), input_paths)
 
 
 def compile_tex_files_to_epub(args: Namespace) -> None:
-    _compile_tex_files_to_epub(output_directory=Path(args.outputdir))
+    input_paths = sorted(map(Path, args.filenames)) if args.filenames else None
+    _compile_tex_files_to_epub(Path(args.outputdir), input_paths)
 
 
 def compile_tex_files_to_docx(args: Namespace) -> None:
-    _compile_tex_files_to_docx(output_directory=Path(args.outputdir))
+    input_paths = sorted(map(Path, args.filenames)) if args.filenames else None
+    _compile_tex_files_to_docx(Path(args.outputdir), input_paths)
 
 
 def main():
@@ -1466,6 +1471,7 @@ def main():
         action='store_true',
         help='Keep recompiling the TeX files as they change',
     )
+    parser_compile_tex_to_pdf.add_argument('filenames', nargs='*')
     parser_compile_tex_to_pdf.set_defaults(func=compile_tex_files_to_pdf)
 
     parser_compile_tex_to_html = subparsers.add_parser(
@@ -1473,6 +1479,7 @@ def main():
         help='Compile all TeX files in this repository to HTML',
     )
     parser_compile_tex_to_html.add_argument('outputdir')
+    parser_compile_tex_to_html.add_argument('filenames', nargs='*')
     parser_compile_tex_to_html.set_defaults(func=compile_tex_files_to_html)
 
     parser_compile_tex_to_epub = subparsers.add_parser(
@@ -1480,6 +1487,7 @@ def main():
         help='Compile all TeX files in this repository to EPUB',
     )
     parser_compile_tex_to_epub.add_argument('outputdir')
+    parser_compile_tex_to_epub.add_argument('filenames', nargs='*')
     parser_compile_tex_to_epub.set_defaults(func=compile_tex_files_to_epub)
 
     parser_compile_tex_files_to_docx = subparsers.add_parser(
@@ -1487,6 +1495,7 @@ def main():
         help='Compile all TeX files in this repository to DOCX',
     )
     parser_compile_tex_files_to_docx.add_argument('outputdir')
+    parser_compile_tex_files_to_docx.add_argument('filenames', nargs='*')
     parser_compile_tex_files_to_docx.set_defaults(func=compile_tex_files_to_docx)
 
     args = parser.parse_args()

--- a/template.py
+++ b/template.py
@@ -1284,6 +1284,8 @@ def _should_compile_tex_file(input_path: Path) -> bool:
 def _compile_tex_files(compile_fn: 'CompilationFunction', *args, input_paths: Optional[Iterable[Path]] = None, **kwargs) -> None:
     if input_paths is None:
         input_paths = list(_find_files(file_types=['tex']))
+    else:
+        input_paths = list(input_paths)
     if not _should_do_full_compile():
         removed_indexes = []
         for input_path_index, input_path in enumerate(input_paths):

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -85,67 +85,65 @@
   \g_istqb_organization_tl
   { ISTQB® }
 \lhead{%
-  \kern 0.1in
   \fontsize{9}{10.8}\selectfont
-  \begin{minipage}[b]{0.7\linewidth}
-    \tl_if_empty:NF
-      \g_istqb_organization_tl
-      {
-        \mbox { \g_istqb_organization_tl }
-        \tl_if_empty:NF
-          \g_istqb_schema_tl
-          { ~ }
-      }
-    \tl_if_empty:NF
-      \g_istqb_schema_tl
-      { \mbox { \g_istqb_schema_tl } }
-    \bool_if:nF
-      {
+  \kern 0.1in
+  \tl_if_empty:NF
+    \g_istqb_organization_tl
+    {
+      \mbox { \g_istqb_organization_tl }
+      \tl_if_empty:NF
+        \g_istqb_schema_tl
+        { ~ }
+    }
+  \tl_if_empty:NF
+    \g_istqb_schema_tl
+    { \mbox { \g_istqb_schema_tl } }
+  \bool_if:nF
+    {
+      \tl_if_empty_p:N
+        \g_istqb_organization_tl &&
+      \tl_if_empty_p:N
+        \g_istqb_schema_tl
+    }
+    { \\ \leavevmode \kern 0.1in }
+  \tl_if_empty:NF
+    \g_istqb_level_tl
+    {
+      \mbox { \g_istqb_level_tl }
+      \tl_if_empty:NF
+        \g_istqb_type_tl
+        { ~ }
+    }
+  \tl_if_empty:NF
+    \g_istqb_type_tl
+    { \mbox { \g_istqb_type_tl } }
+  \bool_if:nF
+    {
+      (
         \tl_if_empty_p:N
-          \g_istqb_organization_tl &&
+          \g_istqb_level_tl &&
         \tl_if_empty_p:N
-          \g_istqb_schema_tl
-      }
-      { \\ }
-    \tl_if_empty:NF
-      \g_istqb_level_tl
-      {
-        \mbox { \g_istqb_level_tl }
-        \tl_if_empty:NF
           \g_istqb_type_tl
-          { ~ }
-      }
-    \tl_if_empty:NF
-      \g_istqb_type_tl
-      { \mbox { \g_istqb_type_tl } }
-    \bool_if:nF
-      {
-        (
-          \tl_if_empty_p:N
-            \g_istqb_level_tl &&
-          \tl_if_empty_p:N
-            \g_istqb_type_tl
-        ) ||
-        (
-          \tl_if_empty_p:N
-            \g_istqb_title_tl &&
-          \tl_if_empty_p:N
-            \g_istqb_code_tl
-        )
-      }
-      { \,--\, }
-    \tl_if_empty:NF
-      \g_istqb_title_tl
-      {
-        \mbox { \g_istqb_title_tl }
-        \tl_if_empty:NF
+      ) ||
+      (
+        \tl_if_empty_p:N
+          \g_istqb_title_tl &&
+        \tl_if_empty_p:N
           \g_istqb_code_tl
-          { ~ }
-      }
-    \tl_if_empty:NF
-      \g_istqb_code_tl
-      { \mbox { ( \g_istqb_code_tl ) } }
-  \end{minipage}
+      )
+    }
+    { \,--\, }
+  \tl_if_empty:NF
+    \g_istqb_title_tl
+    {
+      \mbox { \g_istqb_title_tl }
+      \tl_if_empty:NF
+        \g_istqb_code_tl
+        { ~ }
+    }
+  \tl_if_empty:NF
+    \g_istqb_code_tl
+    { \mbox { ( \g_istqb_code_tl ) } }
 }
 \rhead{%
   \includegraphics[height=\headheight]{\g_istqb_logo_tl}%
@@ -231,9 +229,8 @@
       \begin{minipage}{0.4\linewidth}
       \hfill
       \mbox{\g_istqb_date_tl}
-      \end{minipage}
-      \\[5pt]
-      \fontsize{6}{6}\selectfont
+      \end{minipage}~
+      \fontsize{6}{12}\selectfont
       \textcopyright{}~\istqborgname
     \end{mdframed}
   }


### PR DESCRIPTION
Closes #119 and #123:

![001](https://github.com/user-attachments/assets/2a0e0131-b845-4acc-a17d-edb9f920e955)
![002](https://github.com/user-attachments/assets/8db691bb-083a-477d-ac12-a11f0b736c18)
![003](https://github.com/user-attachments/assets/2d0ef645-5905-4c3a-8b23-0a85114318bb)
![004](https://github.com/user-attachments/assets/3897a182-28cd-4381-b314-03b062bc2f45)