### PR TITLE
Allow hypenation for German language and prevent overlong lines in the traceability matrix section

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: witiko/markdown
-          ref: 3.8.1
+          ref: 3.9.0
           fetch-depth: 0
       - name: Build intermediate image witiko/markdown:latest-minimal
         run: DOCKER_BUILDKIT=1 docker build --build-arg TEXLIVE_TAG=latest-minimal --build-arg DEV_IMAGE=true -t witiko/markdown:latest-minimal .

--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -15,12 +15,10 @@ prefix: EXMPL
 code: CT-EXMPL
 type: Syllabus
 version: v0.1
-date: YYYY/MM/DD
+date: 2024/06/04
 release: For internal use only
 logo: istqb-logo-default
 language: en
-line-numbers: false
-further-reading: true
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules
@@ -146,6 +144,22 @@ This will produce the following output:
 
 Here is the first line of a paragraph  
 and here is the second line of the paragraph.
+
+## Hyphenation
+
+The language of the document controls whether the text will be hyphenated or not. However, you can override the per-language hyphenation settings in the file `metadata.yml`.
+
+If hyphenation is disabled by default for the language of your document, you can enable it manually by writing the following line in the file `metadata.yml`:
+
+```yaml
+hyphenation: true
+```
+
+Conversely, if hyphenation is enabled by default, you can disable it as follows:
+
+```yaml
+hyphenation: false
+```
 
 ## Superscripts and subscripts
 

--- a/example-document/metadata.yml
+++ b/example-document/metadata.yml
@@ -12,6 +12,8 @@ logo: istqb-logo-default
 language: en
 line-numbers: false
 further-reading: true
+# Whether the text should be hyphenated. Uncomment the following line to override the per-language settings.
+#hyphenation: false
 compatibility: |
   Compatible with Syllabus on Foundation and Advanced Levels,
   and Specialist Modules

--- a/languages/cs.yml
+++ b/languages/cs.yml
@@ -1,3 +1,4 @@
+hyphenation: false
 appendix: Příloha
 references: Reference
 further-reading: Další zdroje

--- a/languages/de.yml
+++ b/languages/de.yml
@@ -1,3 +1,4 @@
+hyphenation: true
 appendix: Anhänge
 references: Referenzen
 further-reading: Weitere Literatur

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -1,3 +1,4 @@
+hyphenation: false
 appendix: Appendix
 references: References
 further-reading: Further Reading

--- a/languages/sk.yml
+++ b/languages/sk.yml
@@ -1,3 +1,4 @@
+hyphenation: false
 appendix: Príloha
 references: Referencie
 further-reading: Ďalšie zdroje

--- a/schema/language.yml
+++ b/schema/language.yml
@@ -1,4 +1,5 @@
 babel-language: str()
+hyphenation: bool()
 appendix: str()
 references: str()
 further-reading: str()

--- a/schema/metadata.yml
+++ b/schema/metadata.yml
@@ -18,6 +18,7 @@ docx-output: bool(required=False)
 epub-output: bool(required=False)
 html-output: bool(required=False)
 further-reading: bool(required=False)
+hyphenation: bool(required=False)
 variables: map(str(), key=str(), required=False)
 ---
 third-parties: list(any(str(), include('third-party')))

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -694,6 +694,7 @@
               [ c = 2 ]
               { halign = l, valign = m, bg = istqbbluetableheader }
             \Large
+            \RaggedRight
           }
         \tl_set:NV
           \l_tmpa_tl

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -668,6 +668,7 @@
             rowhead = 1,
             hlines,
             vlines,
+            hspan = minimal,
           }
         \tl_set:Nn
           \l_istqb_traceability_matrix_colspec_tl
@@ -688,7 +689,12 @@
         % Construct the table body for the number of related learning objectives.
         \tl_put_right:Nn
           \l_istqb_traceability_matrix_body_tl
-          { \SetCell [ c = 2 ] { l, bg = istqbbluetableheader } \Large }
+          {
+            \SetCell
+              [ c = 2 ]
+              { halign = l, valign = m, bg = istqbbluetableheader }
+            \Large
+          }
         \tl_set:NV
           \l_tmpa_tl
           \g_istqb_translation_traceability_matrix_business_outcomes_tl

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -114,8 +114,13 @@
     \RequirePackage
       [ shorthands = off ]
       { babel }
-    \bool_if:NF
-      \g_istqb_hyphenation_bool
+    \bool_if:nF
+      {
+        \g_istqb_metadata_hyphenation_specified_bool
+        && \g_istqb_metadata_hyphenation_bool
+        || ! \g_istqb_metadata_hyphenation_specified_bool
+        && \g_istqb_language_hyphenation_bool
+      }
       {
         \tl_set:Nn
           \l_tmpa_tl
@@ -132,12 +137,12 @@
 \tl_new:N
   \g_istqb_babel_language_tl
 \bool_new:N
-  \g_istqb_hyphenation_bool
+  \g_istqb_language_hyphenation_bool
 \keys_define:nn
   { istqb / language }
   {
     babel-language .tl_gset:N = \g_istqb_babel_language_tl,
-    hyphenation .bool_gset:N = \g_istqb_hyphenation_bool,
+    hyphenation .bool_gset:N = \g_istqb_language_hyphenation_bool,
     appendix .tl_gset:N = \istqbappendixname,
     references .tl_gset:N = \istqbrefname,
     further-reading .tl_gset:N = \istqbfurtherreadingname,
@@ -277,6 +282,12 @@
   \g_istqb_further_reading_bool
 \bool_gset_true:N
   \g_istqb_further_reading_bool
+\bool_new:N
+  \g_istqb_metadata_hyphenation_bool
+\bool_new:N
+  \g_istqb_metadata_hyphenation_specified_bool
+\bool_gset_false:N
+  \g_istqb_metadata_hyphenation_specified_bool
 \RequirePackage { lineno }
 \cs_gset:Npn
   \linenumberfont
@@ -298,6 +309,21 @@
     language .tl_gset:N = \g_istqb_language_tl,
     organization .tl_gset:N = \g_istqb_organization_tl,
     further-reading .bool_gset:N = \g_istqb_further_reading_bool,
+    hyphenation .code:n = {
+      \bool_gset_true:N
+        \g_istqb_metadata_hyphenation_specified_bool
+      \str_if_eq:nnTF
+        { #1 }
+        { true }
+        {
+          \bool_gset_true:N
+            \g_istqb_metadata_hyphenation_bool
+        }
+        {
+          \bool_gset_false:N
+            \g_istqb_metadata_hyphenation_bool
+        }
+    },
     line-numbers .code:n = {
       \tl_if_eq:nnT
         { #1 }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -79,7 +79,7 @@
         \group_end:
       },
       jekyllDataProgrammaticString = ,
-      jekyllDataTypographicString = {
+      jekyllData(TypographicString|Boolean) = {
         \tl_set:Nx
           \l_tmpa_tl
           { { \l_istqb_language_position_tl / #1 } }
@@ -104,15 +104,40 @@
     },
   }
 \RequirePackage
-  [ shorthands = off ]
-  { babel }
+  { etoolbox }
+\AtEndPreamble
+  {
+    \exp_args:NV
+      \PassOptionsToPackage
+      \g_istqb_babel_language_tl
+      { babel }
+    \RequirePackage
+      [ shorthands = off ]
+      { babel }
+    \bool_if:NF
+      \g_istqb_hyphenation_bool
+      {
+        \tl_set:Nn
+          \l_tmpa_tl
+          {
+            \babelprovide
+              [ hyphenrules = nohyphenation ]
+          }
+        \exp_args:NNV
+          \tl_use:N
+            \l_tmpa_tl
+          \g_istqb_babel_language_tl
+      }
+  }
+\tl_new:N
+  \g_istqb_babel_language_tl
+\bool_new:N
+  \g_istqb_hyphenation_bool
 \keys_define:nn
   { istqb / language }
   {
-    babel-language .code:n = {
-      \selectlanguage
-        { #1 }
-    },
+    babel-language .tl_gset:N = \g_istqb_babel_language_tl,
+    hyphenation .bool_gset:N = \g_istqb_hyphenation_bool,
     appendix .tl_gset:N = \istqbappendixname,
     references .tl_gset:N = \istqbrefname,
     further-reading .tl_gset:N = \istqbfurtherreadingname,


### PR DESCRIPTION
This PR makes the following changes:
- Enable hyphenation in German documents.
- Break lines in long traceability matrix headers.

This PR also makes the following changes:
- Update `markdown.tex` to version 3.9.0.

Closes #131, #144, and #146.