### PR TITLE
Update translations in the traceability matrix section

### DIFF
--- a/languages/cs.yml
+++ b/languages/cs.yml
@@ -47,6 +47,9 @@ traceability-matrix:
     - Tato sekce uvádí trasovatelnost mezi profesními cíli a`~`{=tex}studijními cíli
     - z`~`{=tex}dokumentu
   business-outcomes: Profesní cíle
+  learning-objective:
+    number: Číslo cíle
+    description: Studijní cíl (úroveň)
 page: [Strana, z]
 provided-by: [Poskytl, Poskytli]
 istqb: International Software Testing Qualifications Board

--- a/languages/de.yml
+++ b/languages/de.yml
@@ -41,6 +41,9 @@ traceability-matrix:
     - Dieser Abschnitt listet die Anzahl der Lernziele des vorliegenden Lehrplans auf, die mit dem geschäftlichen Nutzen in Verbindung stehen, sowie die Verfolgbarkeit zwischen dem geschäftlichen Nutzen des Lehrplans und den Lernzielen
     - des
   business-outcomes: Geschäftlicher Nutzen
+  learning-objective:
+    number: LO-Nummer
+    description: Lernziel (K-level)
 page: [Seite, von]
 provided-by: [Zur Verfügung gestellt von, Zur Verfügung gestellt von]
 istqb: International Software Testing Qualifications Board

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -40,6 +40,9 @@ traceability-matrix:
     - This section lists the traceability between the Business Outcomes and the Learning Objectives
     - of
   business-outcomes: Business Outcomes
+  learning-objective:
+    number: LO Number
+    description: Learning Objective (K-Level)
 page: [Page, of]
 provided-by: [Provided by, Provided by]
 istqb: International Software Testing Qualifications Board

--- a/languages/sk.yml
+++ b/languages/sk.yml
@@ -47,6 +47,9 @@ traceability-matrix:
     - Táto sekcia uvádza trasovateľnosť medzi profesijnými cieľmi a`~`{=tex}študijnými cieľmi
     - z`~`{=tex}dokumentu
   business-outcomes: Profesijné ciele
+  learning-objective:
+    number: Číslo cieľa
+    description: Študijný cieľ (úroveň)
 page: [Strana, z]
 provided-by: [Poskytol, Poskytli]
 istqb: International Software Testing Qualifications Board

--- a/schema/language.yml
+++ b/schema/language.yml
@@ -32,6 +32,9 @@ traceability-matrix:
   section-name: str()
   description: [str(), str()]
   business-outcomes: str()
+  learning-objective:
+    number: str()
+    description: str()
 page: [str(), str()]
 provided-by: [str(), str()]
 istqb: str()

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -539,13 +539,6 @@
                 {}~
               }
             \tl_if_empty:NF
-              \g_istqb_type_tl
-              {
-                \tl_use:N
-                  \g_istqb_type_tl
-                {}~
-              }
-            \tl_if_empty:NF
               \g_istqb_title_tl
               {
                 \tl_use:N
@@ -745,16 +738,6 @@
                   \tl_put_right:NV
                     \l_tmpa_tl
                     \g_istqb_level_tl
-                  \tl_put_right:Nn
-                    \l_tmpa_tl
-                    { ~ }
-                }
-              \tl_if_empty:NF
-                \g_istqb_type_tl
-                {
-                  \tl_put_right:NV
-                    \l_tmpa_tl
-                    \g_istqb_type_tl
                   \tl_put_right:Nn
                     \l_tmpa_tl
                     { ~ }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -251,6 +251,10 @@
   \g_istqb_translation_traceability_matrix_section_name_tl
 \tl_new:N
   \g_istqb_translation_traceability_matrix_business_outcomes_tl
+\tl_new:N
+  \g_istqb_translation_traceability_matrix_learning_objective_number_tl
+\tl_new:N
+  \g_istqb_translation_traceability_matrix_learning_objective_description_tl
 \keys_define:nn
   { istqb / language / traceability-matrix }
   {
@@ -258,6 +262,10 @@
       \g_istqb_translation_traceability_matrix_section_name_tl,
     business-outcomes .tl_gset:N =
       \g_istqb_translation_traceability_matrix_business_outcomes_tl,
+    learning-objective / number .tl_gset:N =
+      \g_istqb_translation_traceability_matrix_learning_objective_number_tl,
+    learning-objective / description .tl_gset:N =
+      \g_istqb_translation_traceability_matrix_learning_objective_description_tl,
   }
 \tl_new:N
   \g_istqb_translation_traceability_matrix_description_tl
@@ -840,10 +848,12 @@
           \l_istqb_traceability_matrix_body_tl
           {
             \SetCell { bg = istqbbluetableheader }
-            Unique~LO
+            \tl_use:N
+              \g_istqb_translation_traceability_matrix_learning_objective_number_tl
             &
             \SetCell { bg = istqbbluetableheader }
-            Learning~Objective~(K-Level)
+            \tl_use:N
+              \g_istqb_translation_traceability_matrix_learning_objective_description_tl
             \\
           }
         % Print out chapters.


### PR DESCRIPTION
This PR makes the following changes:

- Update the English translation of the traceability matrix table headers.
- Add German, Czech, and Slovak translations of the traceability matrix table headers.
- Do not include the document type in the traceability matrix text and table headers.

Closes #148 and #149.