### PR TITLE
Include version number rather than a year in the citations of ISTQB documents

### DIFF
--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -610,7 +610,7 @@ First, you would define the references in file `example-document/bibliography.bi
   title = {Certified Tester},
   subtitle = {Foundation Level Syllabus},
   date = {2023-04-21},
-  note = {Version 4.0},
+  version = {4.0},
   keywords = {istqb}
 }
 

--- a/example-document/bibliography.bib
+++ b/example-document/bibliography.bib
@@ -13,7 +13,7 @@
   title = {Certified Tester},
   subtitle = {Foundation Level Syllabus},
   date = {2023-04-21},
-  note = {Version 4.0},
+  version = {4.0},
   keywords = {istqb}
 }
 

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -294,6 +294,16 @@
 \urlstyle{same}
 \setlength\bibitemsep{0.5\baselineskip}
 
+%% Citation style for ISTQB documents, based on the macros from the standard library `authoryear.cbx`.
+\renewbibmacro*{cite:labeldate+extradate}{%
+  \iffieldundef{version}
+    {%
+      \iffieldundef{labelyear}
+        {}
+        {\printtext[bibhyperref]{\printlabeldateextra}}%
+    }
+    {\printtext[bibhyperref]{v\printfield[default]{version}}}}
+
 %% Bibliographic categories
 \DeclareBibliographyCategory{cited}
 \AtEveryCitekey{\addtocategory{cited}{\thefield{entrykey}}}


### PR DESCRIPTION
After this PR, citations of ISTQB documents look as follows:

![image](https://github.com/user-attachments/assets/d2472bdb-64a9-45ce-a334-49bc7e03220e)
![image](https://github.com/user-attachments/assets/5ffbdf34-944e-48bd-9946-1bd425baeb39)

Closes https://github.com/istqborg/istqb_product_base/issues/155.