### PR TITLE
Allow splitting short questions over more pages with line numbering

### DIFF
--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1,8 +1,8 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesExplPackage
   {markdownthemeistqb_common}%
-  {2025-01-15}%
-  {1.0.1}%
+  {2025-01-17}%
+  {1.0.2}%
   {LaTeX theme for the Markdown Package that contains common code for different types of ISTQB documents}
 
 % Hybrid Markdown + LaTeX text
@@ -347,6 +347,10 @@
   \g_istqb_metadata_hyphenation_specified_bool
 \bool_gset_false:N
   \g_istqb_metadata_hyphenation_specified_bool
+\bool_new:N
+  \g_istqb_metadata_line_numbers_bool
+\bool_gset_false:N
+  \g_istqb_metadata_line_numbers_bool
 \RequirePackage { lineno }
 \cs_gset:Npn
   \linenumberfont
@@ -384,15 +388,28 @@
         }
     },
     line-numbers .code:n = {
-      \tl_if_eq:nnT
+      \str_if_eq:nnTF
         { #1 }
         { true }
-        { \AtBeginDocument { \linenumbers } }
+        {
+          \bool_gset_true:N
+            \g_istqb_metadata_line_numbers_bool
+        }
+        {
+          \bool_gset_false:N
+            \g_istqb_metadata_line_numbers_bool
+        }
     },
     pdf-output .code:n = { },
     docx-output .code:n = { },
     epub-output .code:n = { },
     html-output .code:n = { },
+  }
+\AtBeginDocument
+  {
+    \bool_if:NT
+      \g_istqb_metadata_line_numbers_bool
+      { \linenumbers }
   }
 \markdownSetupSnippet
   { metadata }

--- a/template/markdownthemeistqb_sample-exam_questions.sty
+++ b/template/markdownthemeistqb_sample-exam_questions.sty
@@ -1,8 +1,8 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesExplPackage
   {markdownthemeistqb_sample-exam_questions}%
-  {2025-01-08}%
-  {2.0.0}%
+  {2025-01-17}%
+  {2.0.1}%
   {LaTeX theme for the Markdown Package that typesets ISTQB Sample Exam Questions documents}
 
 % Import common code
@@ -172,18 +172,33 @@
           \l_tmpa_tl
           { #1 }
           {
-            \vbox_set:NV
-              \l_tmpa_box
-              \l_istqb_question_tl
-            \dim_compare:nNnTF
-              { \box_ht:N \l_tmpa_box }
-              >
-              { 0.3 \paperheight }
+            \bool_if:NTF
+              \g_istqb_metadata_line_numbers_bool
               {
+                % In the review version, don't use vertical boxes, since they are incompatible with line numbering.
+                % See <https://github.com/istqborg/istqb_product_base/issues/167>.
                 \tl_use:N
                   \l_istqb_question_tl
               }
-              { \box_use:N \l_tmpa_box }
+              {
+                % In the final version, use vertical boxes to prevent splitting short questions over more pages.
+                % See <https://github.com/istqborg/istqb_product_base/pull/38>.
+                \vbox_set:NV
+                  \l_tmpa_box
+                  \l_istqb_question_tl
+                \dim_compare:nNnTF
+                  { \box_ht:N \l_tmpa_box }
+                  >
+                  { 0.3 \paperheight }
+                  {
+                    \tl_use:N
+                      \l_istqb_question_tl
+                  }
+                  {
+                    \box_use:N
+                      \l_tmpa_box
+                  }
+              }
             \int_incr:N
               \l_tmpa_int
             \par


### PR DESCRIPTION
Closes https://github.com/istqborg/istqb_product_base/issues/167.

Here is a demonstration with the CTAL-TA Sample Exam Questions document shown in https://github.com/istqborg/istqb_product_base/issues/167#issue-2788332429:

![image](https://github.com/user-attachments/assets/242354f3-c658-4c05-b537-955a14419a23)