### PR TITLE
Strip formatting from index terms

### DIFF
--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -866,7 +866,7 @@
 
 % Index
 \RequirePackage{imakeidx}
-\AtBeginDocument{\makeindex[columns=2, columnsep=1cm, noautomatic]}
+\makeindex[columns=2, columnsep=1cm, noautomatic]
 \indexsetup{firstpagestyle=fancy}
 %% Ensure that the index is numbered and part of the table of contents.
 \renewcommand\imki@indexlevel{\section}

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -866,7 +866,7 @@
 
 % Index
 \RequirePackage{imakeidx}
-\makeindex[columns=2, columnsep=1cm, noautomatic]
+\AtBeginDocument{\makeindex[columns=2, columnsep=1cm, noautomatic]}
 \indexsetup{firstpagestyle=fancy}
 %% Ensure that the index is numbered and part of the table of contents.
 \renewcommand\imki@indexlevel{\section}

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1708,48 +1708,11 @@
 
 % Index and multi-row cells
 \RequirePackage{multirow}
-%% Collect index terms from the previous run
+%% Function for indexing terms
 \tl_new:N
   \l_istqb_index_current_term_tl
 \str_new:N
   \l_istqb_index_current_term_str
-\prop_new:N
-  \g_istqb_index_terms_prop
-\tl_const:Nx
-  \c_istqb_index_filename
-  { \c_sys_jobname_str .idx }
-\group_begin:
-  \cs_set:Npn
-    \indexentry
-    #1#2
-    {
-      \tl_set:Nn
-        \l_istqb_index_current_term_tl
-        { #1 }
-      \regex_replace_once:nnN
-        { \| hyperpage $ }
-        { }
-        \l_istqb_index_current_term_tl
-      \str_set:NV
-        \l_istqb_index_current_term_str
-        \l_istqb_index_current_term_tl
-      \prop_gput:NVn
-        \g_istqb_index_terms_prop
-        \l_istqb_index_current_term_str
-        { true }
-    }
-  \file_if_exist:VT
-    \c_istqb_index_filename
-    {
-      \ExplSyntaxOff
-      \file_input:V
-        \c_istqb_index_filename
-      \ExplSyntaxOn
-    }
-\group_end:
-%% Function for indexing terms
-\str_new:N
-  \l_istqb_index_current_lower_cased_term_str
 \cs_new:Nn
   \istqb_index:n
   {
@@ -1764,26 +1727,11 @@
     \str_set:NV
       \l_istqb_index_current_term_str
       \l_istqb_index_current_term_tl
-    % Determine whether there exists a lower-case variant of the term.
-    \str_set:Nx
-      \l_istqb_index_current_lower_cased_term_str
+    % Index a lower-cased variant of the term.
+    \exp_args:Nx
+      \index
       {
         \str_lowercase:V
-          \l_istqb_index_current_term_str
-      }
-    \prop_if_in:NVTF
-      \g_istqb_index_terms_prop
-      \l_istqb_index_current_lower_cased_term_str
-      {
-        % Index the lower-cased term.
-        \exp_args:NV
-          \index
-          \l_istqb_index_current_lower_cased_term_str
-      }
-      {
-        % Index the original term.
-        \exp_args:NV
-          \index
           \l_istqb_index_current_term_str
       }
   }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1708,29 +1708,86 @@
 
 % Index and multi-row cells
 \RequirePackage{multirow}
+%% Collect index terms from the previous run
+\tl_new:N
+  \l_istqb_index_current_term_tl
+\str_new:N
+  \l_istqb_index_current_term_str
+\prop_new:N
+  \g_istqb_index_terms_prop
+\tl_const:Nx
+  \c_istqb_index_filename
+  { \c_sys_jobname_str .idx }
+\group_begin:
+  \cs_set:Npn
+    \indexentry
+    #1#2
+    {
+      \tl_set:Nn
+        \l_istqb_index_current_term_tl
+        { #1 }
+      \regex_replace_once:nnN
+        { \| hyperpage $ }
+        { }
+        \l_istqb_index_current_term_tl
+      \str_set:NV
+        \l_istqb_index_current_term_str
+        \l_istqb_index_current_term_tl
+      \prop_gput:NVn
+        \g_istqb_index_terms_prop
+        \l_istqb_index_current_term_str
+        { true }
+    }
+  \file_if_exist:VT
+    \c_istqb_index_filename
+    {
+      \ExplSyntaxOff
+      \file_input:V
+        \c_istqb_index_filename
+      \ExplSyntaxOn
+    }
+\group_end:
+%% Function for indexing terms
+\str_new:N
+  \l_istqb_index_current_lower_cased_term_str
 \cs_new:Nn
   \istqb_index:n
   {
-    \tl_set:Nn
-      \l_tmpa_tl
-      { #1 }
     % Strip formatting from the term.
+    \tl_set:Nn
+      \l_istqb_index_current_term_tl
+      { #1 }
     \regex_replace_all:nnN
       { \c[CBE]. }
       { }
-      \l_tmpa_tl
-    % Lower-case the term.
-    \tl_set:Nx
-      \l_tmpa_tl
+      \l_istqb_index_current_term_tl
+    \str_set:NV
+      \l_istqb_index_current_term_str
+      \l_istqb_index_current_term_tl
+    % Determine whether there exists a lower-case variant of the term.
+    \str_set:Nx
+      \l_istqb_index_current_lower_cased_term_str
       {
         \str_lowercase:V
-          \l_tmpa_tl
+          \l_istqb_index_current_term_str
       }
-    % Index the term.
-    \exp_args:NV
-      \index
-      \l_tmpa_tl
+    \prop_if_in:NVTF
+      \g_istqb_index_terms_prop
+      \l_istqb_index_current_lower_cased_term_str
+      {
+        % Index the lower-cased term.
+        \exp_args:NV
+          \index
+          \l_istqb_index_current_lower_cased_term_str
+      }
+      {
+        % Index the original term.
+        \exp_args:NV
+          \index
+          \l_istqb_index_current_term_str
+      }
   }
+%% Renderers for index terms and multi-row cells
 \markdownSetup
   {
     bracketedSpans,

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1708,6 +1708,29 @@
 
 % Index and multi-row cells
 \RequirePackage{multirow}
+\cs_new:Nn
+  \istqb_index:n
+  {
+    \tl_set:Nn
+      \l_tmpa_tl
+      { #1 }
+    % Strip formatting from the term.
+    \regex_replace_all:nnN
+      { \c[CBE]. }
+      { }
+      \l_tmpa_tl
+    % Lower-case the term.
+    \tl_set:Nx
+      \l_tmpa_tl
+      {
+        \str_lowercase:V
+          \l_tmpa_tl
+      }
+    % Index the term.
+    \exp_args:NV
+      \index
+      \l_tmpa_tl
+  }
 \markdownSetup
   {
     bracketedSpans,
@@ -1726,12 +1749,8 @@
                   {
                     \def\next####1\markdownRendererBracketedSpanAttributeContextEnd
                       {
-                        \exp_args:Nx
-                        \index
-                          {
-                            \str_lowercase:n
-                              { ####1 }
-                          }
+                        \istqb_index:n
+                          { ####1 }
                         ####1
                       }
                     \next


### PR DESCRIPTION
This PR makes the following changes:

- Strip formatting from index terms.
- Sort index alphabetically.

Closes #171.