### PR TITLE
Support ordering and grouping questions

### DIFF
--- a/schema/questions.yml
+++ b/schema/questions.yml
@@ -14,6 +14,6 @@ question:
   k-level: str()
   number-of-points: int()
   question: str()
-  answers: map(any(str(), int()), key=str())
+  answers: map(any(str(), int()), key=str(), required=False)
   correct: any(str(), list(str()), required=False)
   explanation: str()

--- a/schema/questions.yml
+++ b/schema/questions.yml
@@ -15,5 +15,5 @@ question:
   number-of-points: int()
   question: str()
   answers: map(any(str(), int()), key=str())
-  correct: any(str(), list(str()))
+  correct: any(str(), list(str()), required=False)
   explanation: str()

--- a/template.py
+++ b/template.py
@@ -968,7 +968,8 @@ def _convert_md_questions_to_yaml(include_extra_metadata: bool = True) -> None:
                     print(f'    k-level: {json.dumps(question["k-level"], ensure_ascii=False)}', file=f)
                     print(f'    number-of-points: {json.dumps(question["number-of-points"], ensure_ascii=False)}', file=f)
                     print(f'    question: {json.dumps(question["question"], ensure_ascii=False)}', file=f)
-                    print(f'    answers: {json.dumps(question["answers"], ensure_ascii=False)}', file=f)
+                    if 'answers' in question:
+                        print(f'    answers: {json.dumps(question["answers"], ensure_ascii=False)}', file=f)
                     if 'correct' in question:
                         print(f'    correct: {json.dumps(question["correct"], ensure_ascii=False)}', file=f)
                     print(f'    explanation: {json.dumps(question["explanation"], ensure_ascii=False)}', file=f)

--- a/template.py
+++ b/template.py
@@ -833,8 +833,6 @@ def _read_md_questions(input_files: Iterable[Path]) -> Iterable[Tuple[int, Dict]
                 if 'points' not in input_yaml:
                     raise ValueError(f'Missing YAML key "points" in file "{input_file}" on lines {line_range}')
                 question['number-of-points'] = input_yaml['points']
-                if 'correct' not in input_yaml:
-                    raise ValueError(f'Missing YAML key "correct" in file "{input_file}" on lines {line_range}')
                 question['additional'] = input_yaml.get('additional', False)
 
                 def normalize_correct_answers(correct: Union[List[Union[str, int]], str, int]) -> List[str]:
@@ -872,8 +870,8 @@ def _read_md_questions(input_files: Iterable[Path]) -> Iterable[Tuple[int, Dict]
                             f'Expected a letter, a number, or a list in YAML key "correct" in file "{input_file}" '
                             f'on lines {line_range}, got "{correct}" of type "{type(correct)}"'
                         )
-
-                question['correct'] = normalize_correct_answers(input_yaml['correct'])
+                if 'correct' in input_yaml:
+                    question['correct'] = normalize_correct_answers(input_yaml['correct'])
             elif section == 'question':
                 question['question'] = section_text
             elif section == 'answers':
@@ -971,7 +969,8 @@ def _convert_md_questions_to_yaml(include_extra_metadata: bool = True) -> None:
                     print(f'    number-of-points: {json.dumps(question["number-of-points"], ensure_ascii=False)}', file=f)
                     print(f'    question: {json.dumps(question["question"], ensure_ascii=False)}', file=f)
                     print(f'    answers: {json.dumps(question["answers"], ensure_ascii=False)}', file=f)
-                    print(f'    correct: {json.dumps(question["correct"], ensure_ascii=False)}', file=f)
+                    if 'correct' in question:
+                        print(f'    correct: {json.dumps(question["correct"], ensure_ascii=False)}', file=f)
                     print(f'    explanation: {json.dumps(question["explanation"], ensure_ascii=False)}', file=f)
                     if include_extra_metadata:
                         print(f'    additional: {"true" if "additional" in question and question["additional"] else "false"}', file=f)

--- a/template/markdownthemeistqb_sample-exam_answers.sty
+++ b/template/markdownthemeistqb_sample-exam_answers.sty
@@ -1,8 +1,8 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesExplPackage
   {markdownthemeistqb_sample-exam_answers}%
-  {2025-01-08}%
-  {2.0.0}%
+  {2025-03-14}%
+  {2.1.0}%
   {LaTeX theme for the Markdown Package that typesets ISTQB Sample Exam Answers documents}
 
 % Import common code
@@ -175,11 +175,21 @@
             \int_incr:N
               \l_tmpa_int
             % Record the correct answers.
-            \prop_get:cnN
+            \prop_if_in:cnTF
               { g_istqb_answer_correct
                 _keys_prop }
               { ##1 }
-              \l_tmpa_clist
+              {
+                \prop_get:cnN
+                  { g_istqb_answer_correct
+                    _keys_prop }
+                  { ##1 }
+                  \l_tmpa_clist
+              }
+              {
+                \clist_clear:N
+                  \l_tmpa_clist
+              }
             \tl_put_right:Ne
               \l_istqb_answer_key_table_tl
               { \clist_use:Nn
@@ -402,11 +412,21 @@
             \int_incr:N
               \l_tmpa_int
             % Record the correct answers.
-            \prop_get:cnN
+            \prop_if_in:cnTF
               { g_istqb_answer_correct
                 _keys_prop }
               { ##1 }
-              \l_tmpa_clist
+              {
+                \prop_get:cnN
+                  { g_istqb_answer_correct
+                    _keys_prop }
+                  { ##1 }
+                  \l_tmpa_clist
+              }
+              {
+                \clist_clear:N
+                  \l_tmpa_clist
+              }
             \tl_put_right:Ne
               \l_istqb_answers_table_tl
               { \clist_use:Nn

--- a/template/markdownthemeistqb_sample-exam_questions.sty
+++ b/template/markdownthemeistqb_sample-exam_questions.sty
@@ -1,8 +1,8 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesExplPackage
   {markdownthemeistqb_sample-exam_questions}%
-  {2025-01-08}%
-  {2.0.0}%
+  {2025-03-14}%
+  {2.1.0}%
   {LaTeX theme for the Markdown Package that typesets ISTQB Sample Exam Questions documents}
 
 % Import common code
@@ -110,52 +110,63 @@
               \g_istqb_question_text_prop
               { ##1 }
             % Print answers.
-            \prop_get:NnN
+            \prop_if_in:NnT
               \g_istqb_answer_keys_prop
               { ##1 }
-              \l_tmpa_clist
-            \medskip
-            \setdefaultleftmargin
-              { 1.5em }
-              { }
-              { }
-              { }
-              { }
-              { }
-            \begin { enumerate }
-            \clist_map_inline:Nn
-              \l_tmpa_clist
               {
-                \item [ ####1 ) ]
-                  \prop_item:Nn
-                    \g_istqb_answers_prop
-                    { ##1 / ####1 }
+                \prop_get:NnN
+                  \g_istqb_answer_keys_prop
+                  { ##1 }
+                  \l_tmpa_clist
+                \medskip
+                \setdefaultleftmargin
+                  { 1.5em }
+                  { }
+                  { }
+                  { }
+                  { }
+                  { }
+                \begin { enumerate }
+                \clist_map_inline:Nn
+                  \l_tmpa_clist
+                  {
+                    \item [ ####1 ) ]
+                      \prop_item:Nn
+                        \g_istqb_answers_prop
+                        { ##1 / ####1 }
+                  }
+                \end { enumerate }
               }
-            \end { enumerate }
             \medskip
             % Print the number of questions to select.
-            \prop_get:cnN
+            \prop_if_in:cnT
               { g_istqb_answer_correct
                 _keys_prop }
               { ##1 }
-              \l_tmpa_clist
-            \int_set:Nn
-              \l_tmpb_int
               {
-                \clist_count:N
+                \prop_get:cnN
+                  { g_istqb_answer_correct
+                    _keys_prop }
+                  { ##1 }
                   \l_tmpa_clist
-              }
-            \int_compare:nNnTF
-              { \l_tmpb_int }
-              =
-              { 1 }
-              {
-                \tl_use:N
-                  \g_istqb_translation_select_answers_one_tl
-              }
-              {
-                \tl_use:N
-                  \g_istqb_translation_select_answers_two_tl
+                \int_set:Nn
+                  \l_tmpb_int
+                  {
+                    \clist_count:N
+                      \l_tmpa_clist
+                  }
+                \int_compare:nNnTF
+                  { \l_tmpb_int }
+                  =
+                  { 1 }
+                  {
+                    \tl_use:N
+                      \g_istqb_translation_select_answers_one_tl
+                  }
+                  {
+                    \tl_use:N
+                      \g_istqb_translation_select_answers_two_tl
+                  }
               }
             \group_end:
           }


### PR DESCRIPTION
This PR supports ordering and grouping questions by making the metadata key `correct` and the section `answers` optional in MD question definitions.

This PR closes #179. The PR-less branch `new-question-types` of the repo `istqborg/istqb_product_template` should be merged into branch `main` of the same repository after this PR has been merged.