### PR TITLE
Use explcheck for quality assurance

### DIFF
--- a/.explcheckrc
+++ b/.explcheckrc
@@ -1,0 +1,5 @@
+[defaults]
+ignored_issues = ["s204"]
+max_line_length = 140
+imported_prefixes = ["istqb", "markdown"]
+warnings_are_errors = true

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -9,6 +9,17 @@ permissions:
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
+  explcheck:
+    name: Style check (LaTeX)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/witiko/expltools/explcheck
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run explcheck
+        shell: bash
+        run: explcheck template/*.{tex,sty,cls}
   flake8:
     name: Style check (Python)
     runs-on: ubuntu-latest
@@ -45,6 +56,7 @@ jobs:
   build:
     name: Build Docker image
     needs:
+      - explcheck
       - flake8
       - pytype
     runs-on: ubuntu-latest

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -535,9 +535,9 @@
               \seq_use:Nnnn
               \g_istqb_third_parties_seq
               {
-                { \g_istqb_list_delimiter_two }
-                { \g_istqb_list_delimiter_many }
-                { \g_istqb_list_delimiter_last }
+                { \g_istqb_list_delimiter_two_tl }
+                { \g_istqb_list_delimiter_many_tl }
+                { \g_istqb_list_delimiter_last_tl }
               }
           }
         \par \vspace { 0.3in }
@@ -585,30 +585,30 @@
 % Headings
 \ExplSyntaxOn
 \int_new:N
-  \g_istqb_previous_heading_level
+  \g_istqb_previous_heading_level_int
 \int_gset:Nn
-  \g_istqb_previous_heading_level
+  \g_istqb_previous_heading_level_int
   { 0 }
 \cs_new:Npn
   \istqbupdateheadinglevel
   #1
   {
     \int_if_zero:VF
-      \g_istqb_previous_heading_level
+      \g_istqb_previous_heading_level_int
       {
         % Encourage page breaks before sections
         \penalty -2000
         % Discourage page breaks between sections and subsections in TOC
         \int_compare:nT
-          { \g_istqb_previous_heading_level < #1 }
+          { \g_istqb_previous_heading_level_int < #1 }
           { \addtocontents { toc } { \nopagebreak } }
         % Encourage page breaks between subsections and sections in TOC
         \int_compare:nT
-          { \g_istqb_previous_heading_level > #1 }
+          { \g_istqb_previous_heading_level_int > #1 }
           { \addtocontents { toc } { \pagebreak[0] } }
       }
     \int_gset:Nn
-      \g_istqb_previous_heading_level
+      \g_istqb_previous_heading_level_int
       { #1 }
   }
 \cs_generate_variant:Nn

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -240,7 +240,7 @@
     \tl_gset:Nn
       #1
       { #2 }
-    \regex_match:nnF
+    \regex_if_match:nnF
       { ^, }
       { #2 }
       {
@@ -252,25 +252,25 @@
       #1
       { ~ }
   }
-\tl_new:N \g_istqb_list_delimiter_two
-\tl_new:N \g_istqb_list_delimiter_many
-\tl_new:N \g_istqb_list_delimiter_last
+\tl_new:N \g_istqb_list_delimiter_two_tl
+\tl_new:N \g_istqb_list_delimiter_many_tl
+\tl_new:N \g_istqb_list_delimiter_last_tl
 \keys_define:nn
   { istqb / language / list-delimiters }
   {
     1 .code:n = {
       \__istqb_gset_with_spaces:Nn
-        \g_istqb_list_delimiter_two
+        \g_istqb_list_delimiter_two_tl
         { #1 }
     },
     2 .code:n = {
       \__istqb_gset_with_spaces:Nn
-        \g_istqb_list_delimiter_many
+        \g_istqb_list_delimiter_many_tl
         { #1 }
     },
     3 .code:n = {
       \__istqb_gset_with_spaces:Nn
-        \g_istqb_list_delimiter_last
+        \g_istqb_list_delimiter_last_tl
         { #1 }
     },
   }


### PR DESCRIPTION
This PR introduces a LaTeX linter `explcheck` to continuously check our LaTeX templates, as discussed in https://github.com/istqborg/istqb_product_base/issues/111.