### PR TITLE
Automatically break Markdown tables across pages and add support for multi-column content

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout Git repository istqborg/istqb_product_base
         uses: actions/checkout@v4
       - name: Build temporary Docker image ghcr.io/istqborg/istqb_product_base
-        run: DOCKER_BUILDKIT=1 docker build --build-arg MARKDOWN_VERSION=3.15.0-0-g58d7bf4d-latest-minimal -t ghcr.io/istqborg/istqb_product_base:${{ github.run_id }}-${{ github.sha }} .
+        run: DOCKER_BUILDKIT=1 docker build --build-arg MARKDOWN_VERSION=3.15.0-4-gd3a1c32c-latest-minimal -t ghcr.io/istqborg/istqb_product_base:${{ github.run_id }}-${{ github.sha }} .
       - name: Login to GitHub Packages
         uses: docker/login-action@v3
         with:

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -24,7 +24,6 @@ multirow
 mwe
 needspace
 newunicodechar
-nicematrix
 ninecolors
 supertabular
 tabularray

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -20,7 +20,6 @@ luaxml
 make4ht
 makeindex
 mdframed
-multirow
 mwe
 needspace
 newunicodechar

--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -399,27 +399,26 @@ The second line of the table allows you to define the formatting of columns:
   uniform portion of the remaining page width. The cells will wrap over
   multiple lines and are therefore well-suited for long paragraphs of text.
 
-If your table overflows a page, make sure that all columns with long texts
-are specified as `----`, not as `---:`, `:---`, or `:--:`.
-
 You may also use parameter `rows` and `cells` to produce multi-row and
 multi-column cells:
 
 ``` md
 | Clause | ISO/IEC 25010:2023 | ISO/IEC 25010:2011 | Notes |
-|:-------|:-------------------|:-------------------|:------|
+|:-------|--------------------|--------------------|-------|
 | 3.4.6  | Inclusivity | [Accessibility]{rows=2} | [Split and renamed]{rows=2} |
 | 3.4.7  | User assistance |
-| 3.4.8  | [Self-descriptiveness]{cells=2} |  | New subcharacteristic |
+| 3.4.8  | [Self-descriptiveness]{rows=2 cols=3} |
+| 3.4.9  |
 ```
 
 This will produce the following output:
 
 | Clause | ISO/IEC 25010:2023 | ISO/IEC 25010:2011 | Notes |
-|:-------|:-------------------|:-------------------|:------|
+|:-------|--------------------|--------------------|-------|
 | 3.4.6  | Inclusivity | [Accessibility]{rows=2} | [Split and renamed]{rows=2} |
 | 3.4.7  | User assistance |
-| 3.4.8  | [Self-descriptiveness]{cells=2} |  | New subcharacteristic |
+| 3.4.8  | [Self-descriptiveness]{rows=2 cols=3} |
+| 3.4.9  |
 
 You can add a caption to the table as follows:
 

--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -402,7 +402,8 @@ The second line of the table allows you to define the formatting of columns:
 If your table overflows a page, make sure that all columns with long texts
 are specified as `----`, not as `---:`, `:---`, or `:--:`.
 
-You may also use parameter `rows` to produce multi-row cells:
+You may also use parameter `rows` and `cells` to produce multi-row and
+multi-column cells:
 
 ``` md
 | Clause | ISO/IEC 25010:2023 | ISO/IEC 25010:2011 | Notes |

--- a/example-document/02-markdown-guidelines.md
+++ b/example-document/02-markdown-guidelines.md
@@ -407,18 +407,18 @@ You may also use parameter `rows` to produce multi-row cells:
 ``` md
 | Clause | ISO/IEC 25010:2023 | ISO/IEC 25010:2011 | Notes |
 |:-------|:-------------------|:-------------------|:------|
-| 3.4.6  | Inclusivity | [Accessibility]{rows=3} | [Split and renamed]{rows=2} |
+| 3.4.6  | Inclusivity | [Accessibility]{rows=2} | [Split and renamed]{rows=2} |
 | 3.4.7  | User assistance |
-| 3.4.8  | Self-descriptiveness |  | New subcharacteristic |
+| 3.4.8  | [Self-descriptiveness]{cells=2} |  | New subcharacteristic |
 ```
 
 This will produce the following output:
 
 | Clause | ISO/IEC 25010:2023 | ISO/IEC 25010:2011 | Notes |
 |:-------|:-------------------|:-------------------|:------|
-| 3.4.6  | Inclusivity | [Accessibility]{rows=3} | [Split and renamed]{rows=2} |
+| 3.4.6  | Inclusivity | [Accessibility]{rows=2} | [Split and renamed]{rows=2} |
 | 3.4.7  | User assistance |
-| 3.4.8  | Self-descriptiveness |  | New subcharacteristic |
+| 3.4.8  | [Self-descriptiveness]{cells=2} |  | New subcharacteristic |
 
 You can add a caption to the table as follows:
 

--- a/template.py
+++ b/template.py
@@ -1338,16 +1338,16 @@ def _should_compile_tex_file(input_path: Path) -> bool:
 def _compile_tex_files(compile_fn: 'CompilationFunction', *args, input_paths: Optional[Iterable[Path]] = None, **kwargs) -> None:
     if input_paths is None:
         input_paths = list(_find_files(file_types=['tex']))
+        if not _should_do_full_compile():
+            removed_indexes = []
+            for input_path_index, input_path in enumerate(input_paths):
+                if not _should_compile_tex_file(input_path):
+                    removed_indexes.append(input_path_index)
+                    LOGGER.info('Skipped the compilation of file "%s" because it has not changed in this branch', input_path)
+            for removed_index in reversed(removed_indexes):
+                del input_paths[removed_index]
     else:
         input_paths = list(input_paths)
-    if not _should_do_full_compile():
-        removed_indexes = []
-        for input_path_index, input_path in enumerate(input_paths):
-            if not _should_compile_tex_file(input_path):
-                removed_indexes.append(input_path_index)
-                LOGGER.info('Skipped the compilation of file "%s" because it has not changed in this branch', input_path)
-        for removed_index in reversed(removed_indexes):
-            del input_paths[removed_index]
 
     if not input_paths:
         return

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -28,7 +28,8 @@
 
 %% Landscape content
 \ExplSyntaxOn
-\def \istqblandscapebegin
+\cs_new_protected:Npn
+  \istqblandscapebegin
   {
     \group_begin:
     \paperwidth = \pdfpageheight
@@ -42,7 +43,8 @@
     \pdfpagewidth = \paperwidth
     \pdfpageheight = \paperheight
   }
-\def \istqblandscapeend
+\cs_new_protected:Npn
+  \istqblandscapeend
   {
     \clearpage
     \group_end:
@@ -345,7 +347,7 @@
 
 %% Reference printing
 \ExplSyntaxOn
-\cs_new:Npn
+\cs_new_protected:Npn
   \printistqbbibliography
   {
     \nocite
@@ -589,7 +591,7 @@
 \int_gset:Nn
   \g_istqb_previous_heading_level_int
   { 0 }
-\cs_new:Npn
+\cs_new_protected:Npn
   \istqbupdateheadinglevel
   #1
   {
@@ -1037,7 +1039,7 @@
   \l_istqb_external_document_basename_tl
 \int_new:N
   \l_istqb_external_document_last_page_int
-\cs_new:Nn
+\cs_new_protected:Nn
   \istqb_structure_tables:n
   {
     \pdfximage

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -1001,12 +1001,12 @@
 \RequirePackage{tabularray}
 \ExplSyntaxOn
 \NewTblrEnviron
-  { istqbtable }
+  { istqb table }
 \SetTblrOuter
-  [ istqbtable ]
+  [ istqb table ]
   { long }
 \SetTblrInner
-  [ istqbtable ]
+  [ istqb table ]
   {
     rowhead = 1,
     row { 1 } = { istqb gray table header },

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -1016,6 +1016,8 @@
     long,
     entry = none,
     label = none,
+    presep = \medskipamount,
+    postsep = \medskipamount,
   }
 \SetTblrInner
   [ istqb table ]
@@ -1023,6 +1025,9 @@
     rowhead = 1,
     row { 1 } = { istqb gray table header },
     hlines,
+    stretch = 0,
+    rows = { ht = \baselineskip },
+    colsep = 3pt,
   }
 \ExplSyntaxOff
 

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -994,40 +994,24 @@
 \RequirePackage{hyperref}
 
 % Tables
-\RequirePackage{nicematrix, tabularx}
-\RequirePackage{xcolor, colortbl}
+\RequirePackage{xcolor}
 \definecolor{istqbgraytableheader}{HTML}{D9D9D9}
 \definecolor{istqbbluetableheader}{HTML}{B5C5E5}
 \definecolor{istqbgreentableheader}{HTML}{C5E0B3}
+\RequirePackage{tabularray}
 \ExplSyntaxOn
-\newenvironment
+\NewTblrEnviron
   { istqbtable }
-  [ 1 ]
+\SetTblrOuter
+  [ istqbtable ]
+  { long }
+\SetTblrInner
+  [ istqbtable ]
   {
-    \renewcommand { \arraystretch }{ 1.25 }  % Set vertical cell margins
-    \setlength \tabcolsep { 3pt }  % Set horizontal cell margins
-    \str_if_in:nnTF
-      { #1 }
-      { X }
-      {
-        \cs_set:Npn
-          \endistqbtable
-          { \end { NiceTabularX } }
-        \begin { NiceTabularX } \linewidth { #1 } \hline
-      }
-      {
-        \cs_set:Npn
-          \endistqbtable
-          {
-            \end { NiceTabular }
-            \par
-          }
-        \centering
-        \begin { NiceTabular } { #1 } \hline
-      }
-    \RowStyle [ nb-rows=1, rowcolor=istqbgraytableheader ] { }  % Color table head
+    rowhead = 1,
+    row { 1 } = { istqb gray table header },
+    hlines,
   }
-  { }
 \ExplSyntaxOff
 
 %% Revision History

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -1003,6 +1003,7 @@
 \DeclareTblrTemplate { contfoot } { default } { }
 \DeclareTblrTemplate { conthead } { default } { }
 \DeclareTblrTemplate { caption } { default } { }
+\DeclareTblrTemplate { caption-sep } { default } { :~ }
 \DeclareTblrTemplate { conthead } { default } { }
 \DeclareTblrTemplate { capcont } { default } { }
 \NewTblrEnviron

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -1000,6 +1000,11 @@
 \definecolor{istqbgreentableheader}{HTML}{C5E0B3}
 \RequirePackage{tabularray}
 \ExplSyntaxOn
+\DeclareTblrTemplate { contfoot } { default } { }
+\DeclareTblrTemplate { conthead } { default } { }
+\DeclareTblrTemplate { caption } { default } { }
+\DeclareTblrTemplate { conthead } { default } { }
+\DeclareTblrTemplate { capcont } { default } { }
 \NewTblrEnviron
   { istqb table }
 \SetTblrOuter

--- a/template/istqb.cls
+++ b/template/istqb.cls
@@ -1009,7 +1009,11 @@
   { istqb table }
 \SetTblrOuter
   [ istqb table ]
-  { long }
+  {
+    long,
+    entry = none,
+    label = none,
+  }
 \SetTblrInner
   [ istqb table ]
   {

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1560,7 +1560,7 @@
     \fi \markdownLaTeXRenderTableRow
   }
 \regex_const:Nn
-  \c_istqb_multi_row_cell_regex
+  \c_istqb_multi_row_and_multi_column_cell_regex
    {
      \c { markdownRendererAttributeKeyValue }
      \cB\{ ( rows | cells ) \cE\}
@@ -1570,9 +1570,9 @@
   \markdownLaTeXRenderTableCell #1
   {
     \advance \markdownLaTeXColumnCounter by 1 \relax
-    % Multi-row and multi-cell contents
+    % Multi-row and multi-column contents
     \regex_extract_all:NnNT
-      \c_istqb_multi_row_cell_regex
+      \c_istqb_multi_row_and_multi_column_cell_regex
       { #1 }
       \l_tmpa_seq
       {

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1617,21 +1617,18 @@
               {
                 \group_begin:
                 \SetTblrTemplate { caption } { normal }
+                \SetTblrOuter
+                  [ istqb table ]
+                  {
+                    entry = { #1 },
+                    caption = { #1 },
+                    label = { \l_istqb_table_identifier_tl },
+                  }
               }
-            \addto@hook
-              \markdownLaTeXTableEnd
-              { \group_end: }
           }
         \addto@hook
           \markdownLaTeXTable
           { \begin { istqb table } }
-        \tl_if_empty:nF
-          { #1 }
-          {
-            \addto@hook
-              \markdownLaTeXTable
-              { [ caption = { #1 } ] }
-          }
         \markdownLaTeXRowCounter = 0
         \markdownLaTeXRowTotal = #2
         \markdownLaTeXColumnTotal = #3

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1185,7 +1185,7 @@
                         \ifnum \markdownLaTeXRowCounter > \markdownLaTeXRowTotal \relax
                           \addto@hook
                             \markdownLaTeXTable
-                            { \end { istqbrevisionhistory } }
+                            { \end { istqb revision history } }
                           \the \markdownLaTeXTable
                           \expandafter \@gobble
                         \fi \markdownLaTeXRenderTableRow
@@ -1206,7 +1206,7 @@
                             \markdownLaTeXTableAlignment = { }
                             \addto@hook
                               \markdownLaTeXTable
-                              { \begin { istqbrevisionhistory } }
+                              { \begin { istqb revision history } }
                             \markdownLaTeXRowCounter = 0
                             \markdownLaTeXRowTotal = ####2
                             \markdownLaTeXColumnTotal = ####3
@@ -1401,7 +1401,7 @@
                             \tl_set:Nn
                               \l_istqb_business_outcomes_table_tl
                               {
-                                \begin { istqbtable } { |l|X| }
+                                \begin { istqb table } { |l|X| }
                                 \istqbbusinessoutcomecode &
                                 \istqbbusinessoutcomedescription \\ \hline
                               }
@@ -1431,7 +1431,7 @@
                                     \tl_put_right:Nn
                                       \l_istqb_business_outcomes_table_tl
                                       {
-                                        \end { istqbtable }
+                                        \end { istqb table }
                                       }
                                     \tl_use:N
                                       \l_istqb_business_outcomes_table_tl
@@ -1670,13 +1670,13 @@
         \markdownLaTeXTable = { }
         \markdownLaTeXTableAlignment = { | }
         \markdownLaTeXTableEnd = {
-          \end { istqbtable }
+          \end { istqb table }
           \bool_gset_false:N
             \g_istqb_intable_bool
         }
         \addto@hook
           \markdownLaTeXTable
-          { \begin { istqbtable } }
+          { \begin { istqb table } }
         \tl_if_empty:nF
           { #1 }
           {

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1538,7 +1538,8 @@
   { x }
 
 % Tables
-\def \markdownLaTeXRenderTableRow #1
+\cs_gset_protected:Npn
+  \markdownLaTeXRenderTableRow #1
   {
     \markdownLaTeXColumnCounter = 0
     \ifnum \markdownLaTeXRowCounter = 0 \relax
@@ -1565,7 +1566,8 @@
      \cB\{ ( rows | cells ) \cE\}
      \cB\{ ( [1-9][0-9]* ) \cE\}
    }
-\def \markdownLaTeXRenderTableCell #1
+\cs_gset_protected:Npn
+  \markdownLaTeXRenderTableCell #1
   {
     \advance \markdownLaTeXColumnCounter by 1 \relax
     % Multi-row and multi-cell contents

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -240,7 +240,7 @@
     1 .tl_gset:N = \istqbbusinessoutcomecode,
     2 .tl_gset:N = \istqbbusinessoutcomedescription,
   }
-\cs_new:Nn
+\cs_new_protected:Nn
   \__istqb_gset_with_spaces:Nn
   {
     \tl_gset:Nn
@@ -616,7 +616,7 @@
       },
       jekyllDataEnd += {
         \istqblandscapeend
-        \cs_gset:Npn
+        \cs_gset_protected:Npn
           \markdownRendererDocumentBegin
           {
             \restoregeometry
@@ -1472,7 +1472,7 @@
   }
 
 %% Lists of hands-on objectives at the beginnings of chapters
-\cs_new:Npn
+\cs_new_protected:Npn
   \istqbregisterhandsonobjective
   #1#2#3#4
   {
@@ -1511,7 +1511,7 @@
       { #1 }
       \l_tmpa_tl
   }
-\cs_new:Nn
+\cs_new_protected:Nn
   \istqb_typeset_hands_on_objectives:n
   {
     \prop_get:NnNT
@@ -1825,7 +1825,7 @@
   \l_istqb_index_current_term_tl
 \str_new:N
   \l_istqb_index_current_term_str
-\cs_new:Nn
+\cs_new_protected:Nn
   \istqb_index:n
   {
     % Strip formatting from the term.

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1674,39 +1674,16 @@
           \bool_gset_false:N
             \g_istqb_intable_bool
         }
+        \addto@hook
+          \markdownLaTeXTable
+          { \begin { istqbtable } }
         \tl_if_empty:nF
           { #1 }
           {
             \addto@hook
               \markdownLaTeXTable
-              {
-                \begin { table }
-                \centering
-              }
-            \addto@hook
-              \markdownLaTeXTableEnd
-              {
-                \caption { #1 }
-              }
-            \tl_if_empty:NF
-              \l_istqb_table_identifier_tl
-              {
-                \addto@hook
-                  \markdownLaTeXTableEnd
-                  {
-                    \label
-                      { \l_istqb_table_identifier_tl }
-                  }
-              }
-            \addto@hook
-              \markdownLaTeXTableEnd
-              {
-                \end { table }
-              }
+              { [ caption = { #1 } ] }
           }
-        \addto@hook
-          \markdownLaTeXTable
-          { \begin { istqbtable } }
         \markdownLaTeXRowCounter = 0
         \markdownLaTeXRowTotal = #2
         \markdownLaTeXColumnTotal = #3

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1538,7 +1538,6 @@
   { x }
 
 % Tables
-\prop_new:N \g_istqb_multi_row_prop
 \def \markdownLaTeXRenderTableRow #1
   {
     \markdownLaTeXColumnCounter = 0
@@ -1558,6 +1557,60 @@
       \the \markdownLaTeXTable
       \expandafter \@gobble
     \fi \markdownLaTeXRenderTableRow
+  }
+\regex_const:Nn
+  \c_istqb_multi_row_cell_regex
+   {
+     \c { markdownRendererAttributeKeyValue }
+     \cB\{ ( rows | cells ) \cE\}
+     \cB\{ ( [1-9][0-9]* ) \cE\}
+   }
+\def \markdownLaTeXRenderTableCell #1
+  {
+    \advance \markdownLaTeXColumnCounter by 1 \relax
+    % Multi-row and multi-cell contents
+    \regex_extract_all:NnNT
+      \c_istqb_multi_row_cell_regex
+      { #1 }
+      \l_tmpa_seq
+      {
+        \int_step_inline:nnnn
+          { 2 }
+          { 2 }
+          { \seq_count:N \l_tmpa_seq }
+          {
+            \addto@hook
+              \markdownLaTeXTable
+              { \SetCell }
+            \str_case:en
+              { \seq_item:Nn \l_tmpa_seq { ##1 } }
+              {
+                { rows }
+                {
+                  \exp_args:NNx
+                    \addto@hook
+                    \markdownLaTeXTable
+                    { [ r = \seq_item:Nn \l_tmpa_seq { ##1 + 1 } ] }
+                }
+                { cells }
+                {
+                  \exp_args:NNx
+                    \addto@hook
+                    \markdownLaTeXTable
+                    { [ c = \seq_item:Nn \l_tmpa_seq { ##1 + 1 } ] }
+                }
+              }
+            \addto@hook
+              \markdownLaTeXTable
+              { { c } }
+          }
+      }
+    \ifnum \markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal\relax
+      \addto@hook \markdownLaTeXTable { #1 & }
+    \else
+      \addto@hook \markdownLaTeXTable { #1 \\ }
+      \expandafter \@gobble
+    \fi \markdownLaTeXRenderTableCell
   }
 \def \markdownLaTeXReadAlignments #1
   {
@@ -1598,8 +1651,6 @@
           }
       },
       table = {
-        \prop_clear:N
-          \g_istqb_multi_row_prop
         \bool_gset_true:N
           \g_istqb_intable_bool
         \markdownLaTeXTable = { }
@@ -1820,8 +1871,7 @@
     citations,
   }
 
-% Index and multi-row cells
-\RequirePackage{multirow}
+% Index
 %% Function for indexing terms
 \tl_new:N
   \l_istqb_index_current_term_tl
@@ -1849,12 +1899,13 @@
           \l_istqb_index_current_term_str
       }
   }
-%% Renderers for index terms and multi-row cells
+%% Renderers for index terms
 \markdownSetup
   {
     bracketedSpans,
     renderers = {
-      bracketedSpanAttributeContextBegin = {
+      bracketedSpan = { #1 },
+      bracketedSpanAttributeContextBegin += {
         \markdownSetup
           {
             renderers = {
@@ -1866,49 +1917,19 @@
                   { ##1 }
                   { index }
                   {
-                    \def\next####1\markdownRendererBracketedSpanAttributeContextEnd
+                    \markdownSetup
                       {
-                        \istqb_index:n
-                          { ####1 }
-                        ####1
+                        renderers = {
+                          bracketedSpan ^= {
+                            \istqb_index:n
+                              { ####1 }
+                          },
+                        },
                       }
-                    \next
-                  }
-              },
-              %% Multi-row cells
-              attributeKeyValue += {
-                \str_if_eq:nnT
-                  { ##1 }
-                  { rows }
-                  {
-                    \def\next####1\markdownRendererBracketedSpanAttributeContextEnd
-                      {
-                        \multirow
-                          { ##2 }
-                          { * }
-                          { ####1 }
-                        \int_step_inline:nnn
-                          { \the \markdownLaTeXRowCounter }
-                          { \the \markdownLaTeXRowCounter + ##2 - 2 }
-                          {
-                            \tl_set:Nn
-                              \l_tmpa_tl
-                              { ########1, }
-                            \tl_put_right:Nx
-                              \l_tmpa_tl
-                              { \the \markdownLaTeXColumnCounter }
-                            \prop_gput:NVn
-                              \g_istqb_multi_row_prop
-                              \l_tmpa_tl
-                              { true }
-                          }
-                      }
-                    \next
                   }
               },
             }
           }
       },
-      bracketedSpanAttributeContextEnd = ,
     }
   }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1397,7 +1397,7 @@
                               {
                                 \begin { istqb table } { |l|X| }
                                 \istqbbusinessoutcomecode &
-                                \istqbbusinessoutcomedescription \\ \hline
+                                \istqbbusinessoutcomedescription \\
                               }
                             \markdownSetup
                               {
@@ -1416,7 +1416,7 @@
                                           \l_istqb_business_outcomes_table_tl
                                           {
                                             \g_istqb_prefix_tl - BO########1 &
-                                            ################1 \\ \hline
+                                            ################1 \\
                                           }
                                       }
                                     \next

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -736,12 +736,6 @@
     renderers = {
       jekyllDataEnd += {
         \group_begin:
-        % Set how the table looks.
-        \DeclareTblrTemplate { contfoot-text } { default } { }
-        \DeclareTblrTemplate { conthead-text } { default } { }
-        \DeclareTblrTemplate { caption } { default } { }
-        \DeclareTblrTemplate { conthead } { default } { }
-        \DeclareTblrTemplate { capcont } { default } { }
         % Construct the table parameters.
         \tl_put_right:Nn
           \l_istqb_traceability_matrix_parameters_tl
@@ -1615,6 +1609,19 @@
           \bool_gset_false:N
             \g_istqb_intable_bool
         }
+        \tl_if_empty:nF
+          { #1 }
+          {
+            \addto@hook
+              \markdownLaTeXTable
+              {
+                \group_begin:
+                \SetTblrTemplate { caption } { normal }
+              }
+            \addto@hook
+              \markdownLaTeXTableEnd
+              { \group_end: }
+          }
         \addto@hook
           \markdownLaTeXTable
           { \begin { istqb table } }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1577,67 +1577,8 @@
       \expandafter \@gobble
     \fi \markdownLaTeXReadAlignments
   }
-\def \markdownLaTeXRenderTableCell #1
-  {
-    \advance \markdownLaTeXColumnCounter by 1 \relax
-    \tl_set:Nn
-      \l_tmpa_tl
-      { \markdownLaTeXRowCounter = }
-    \tl_put_right:Nx
-      \l_tmpa_tl
-      { \the \markdownLaTeXRowCounter }
-    \tl_put_right:Nn
-      \l_tmpa_tl
-      { \relax }
-    \tl_put_right:Nn
-      \l_tmpa_tl
-      { \markdownLaTeXColumnCounter = }
-    \tl_put_right:Nx
-      \l_tmpa_tl
-      { \the \markdownLaTeXColumnCounter }
-    \tl_put_right:Nn
-      \l_tmpa_tl
-      { \relax }
-    \exp_args:NNV
-      \addto@hook
-      \markdownLaTeXTable
-      \l_tmpa_tl
-    \ifnum \markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal \relax
-      \addto@hook
-        \markdownLaTeXTable
-        { #1 & }
-    \else
-      \addto@hook
-        \markdownLaTeXTable
-        {
-          #1
-          \tl_set:Nn
-            \l_tmpa_tl
-            { \\ }
-          \int_step_inline:nn
-            { \the \markdownLaTeXColumnTotal }
-            {
-              \tl_set:Nx
-                \l_tmpb_tl
-                { \the \markdownLaTeXRowCounter }
-              \tl_put_right:Nn
-                \l_tmpb_tl
-                { ,##1 }
-              \prop_if_in:NVF
-                \g_istqb_multi_row_prop
-                \l_tmpb_tl
-                {
-                  \tl_put_right:Nn
-                    \l_tmpa_tl
-                    { \cline { ##1 - ##1 } }
-                }
-            }
-          \tl_use:N
-            \l_tmpa_tl
-        }
-      \expandafter \@gobble
-    \fi \markdownLaTeXRenderTableCell
-  }
+% TODO: Reintroduce support for multi-row cells in a way that is compatible with
+% the `tabularray` package.
 \bool_new:N \g_istqb_intable_bool
 \tl_new:N \l_istqb_table_identifier_tl
 \markdownSetup

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1915,7 +1915,6 @@
   {
     bracketedSpans,
     renderers = {
-      bracketedSpan = { #1 },
       bracketedSpanAttributeContextBegin += {
         \markdownSetup
           {

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1563,7 +1563,7 @@
   \c_istqb_multi_row_and_multi_column_cell_regex
    {
      \c { markdownRendererAttributeKeyValue }
-     \cB\{ ( rows | cells ) \cE\}
+     \cB\{ ( rows | cols ) \cE\}
      \cB\{ ( [1-9][0-9]* ) \cE\}
    }
 \cs_gset_protected:Npn
@@ -1571,6 +1571,9 @@
   {
     \advance \markdownLaTeXColumnCounter by 1 \relax
     % Multi-row and multi-column contents
+    \clist_clear:N
+      \l_tmpa_clist
+      { }
     \regex_extract_all:NnNT
       \c_istqb_multi_row_and_multi_column_cell_regex
       { #1 }
@@ -1578,34 +1581,40 @@
       {
         \int_step_inline:nnnn
           { 2 }
-          { 2 }
+          { 3 }
           { \seq_count:N \l_tmpa_seq }
           {
-            \addto@hook
-              \markdownLaTeXTable
-              { \SetCell }
             \str_case:en
               { \seq_item:Nn \l_tmpa_seq { ##1 } }
               {
                 { rows }
                 {
-                  \exp_args:NNx
-                    \addto@hook
-                    \markdownLaTeXTable
-                    { [ r = \seq_item:Nn \l_tmpa_seq { ##1 + 1 } ] }
+                  \clist_put_right:Nx
+                    \l_tmpa_clist
+                    { r = \seq_item:Nn \l_tmpa_seq { ##1 + 1 } }
                 }
-                { cells }
+                { cols }
                 {
-                  \exp_args:NNx
-                    \addto@hook
-                    \markdownLaTeXTable
-                    { [ c = \seq_item:Nn \l_tmpa_seq { ##1 + 1 } ] }
+                  \clist_put_right:Nx
+                    \l_tmpa_clist
+                    { c = \seq_item:Nn \l_tmpa_seq { ##1 + 1 } }
                 }
               }
-            \addto@hook
-              \markdownLaTeXTable
-              { { c } }
           }
+      }
+    \clist_if_empty:NF
+      \l_tmpa_clist
+      {
+        \addto@hook
+          \markdownLaTeXTable
+          { \SetCell [ }
+        \exp_args:NNV
+          \addto@hook
+          \markdownLaTeXTable
+          \l_tmpa_clist
+        \addto@hook
+          \markdownLaTeXTable
+          { ] { c } }
       }
     \ifnum \markdownLaTeXColumnCounter < \markdownLaTeXColumnTotal\relax
       \addto@hook \markdownLaTeXTable { #1 & }

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -737,11 +737,11 @@
       jekyllDataEnd += {
         \group_begin:
         % Set how the table looks.
-        \DefTblrTemplate { contfoot-text } { default } { }
-        \DefTblrTemplate { conthead-text } { default } { }
-        \DefTblrTemplate { caption } { default } { }
-        \DefTblrTemplate { conthead } { default } { }
-        \DefTblrTemplate { capcont } { default } { }
+        \DeclareTblrTemplate { contfoot-text } { default } { }
+        \DeclareTblrTemplate { conthead-text } { default } { }
+        \DeclareTblrTemplate { caption } { default } { }
+        \DeclareTblrTemplate { conthead } { default } { }
+        \DeclareTblrTemplate { capcont } { default } { }
         % Construct the table parameters.
         \tl_put_right:Nn
           \l_istqb_traceability_matrix_parameters_tl

--- a/template/markdownthemeistqb_common.sty
+++ b/template/markdownthemeistqb_common.sty
@@ -1623,6 +1623,8 @@
                     entry = { #1 },
                     caption = { #1 },
                     label = { \l_istqb_table_identifier_tl },
+                    presep = 1.5 \bigskipamount,
+                    postsep = 1.5 \bigskipamount,
                   }
               }
           }

--- a/template/markdownthemeistqb_sample-exam_answers.sty
+++ b/template/markdownthemeistqb_sample-exam_answers.sty
@@ -66,7 +66,7 @@
   { >{ \centering\arraybackslash } p { #1 } }
 \tl_new:N
   \l_istqb_answer_key_table_tl
-\cs_new:Nn
+\cs_new_protected:Nn
   \istqb_print_answer_key:n
   {
     % Start a two-column layout
@@ -297,7 +297,7 @@
       }
   }
 \RequirePackage { paralist }
-\cs_new:Nn
+\cs_new_protected:Nn
   \istqb_print_answers:n
   {
     \group_begin:

--- a/template/markdownthemeistqb_sample-exam_questions.sty
+++ b/template/markdownthemeistqb_sample-exam_questions.sty
@@ -32,7 +32,7 @@
 \RequirePackage { paralist }
 \tl_new:N
   \l_istqb_question_tl
-\cs_new:Nn
+\cs_new_protected:Nn
   \istqb_print_questions:n
   {
     \int_set:Nn


### PR DESCRIPTION
This PR introduces the following changes:

* Markdown tables can now automatically break across pages.

This closes ticket #206.

In addition, this PR extends support for complex table layouts by adding:

* Support for multi-column cells alongside the existing support for multi-row cells.

Here is how that looks in practice:

![image](https://github.com/user-attachments/assets/75d27378-b3c6-4837-9c87-91f3e7b4d912)

This aligns with the original requirements from ticket #107, before the scope was temporarily reduced to multi-row cells only due to limitations in the LaTeX packages previously used for table generation.