### PR TITLE
Add `compile-tex-to-md` action to `template.py`

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -209,6 +209,43 @@ jobs:
         with:
           name: DOCX
           path: docx/
+  produce-md:
+    name: Produce MD documents
+    needs:
+      - validate
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/istqborg/istqb_product_base:latest
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set safe Git directory
+        # This should have been done by the previous step.
+        # See also: <https://github.com/actions/checkout/issues/915>.
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Clone repository istqb_product_base
+        # Only update the Docker image a) in PRs from the istqborg/istqb_product_base repo and b) in other repos that use
+        # a specific branch/ref from the istqborg/istqb_product_base repo. In all other scenarios, just use the Docker image
+        # ghcr.io/istqborg/istqb_product_base:latest directly and do not waste time trying to update it, since this is
+        # quicker and more robust, see also the discussion in <https://github.com/istqborg/istqb_product_base/issues/178>.
+        if: (github.repository == 'istqborg/istqb_product_base' && github.ref != 'refs/heads/main') || (inputs.base-version && inputs.base-version != 'main')
+        run: |
+          set -ex
+          rm -rf /opt/istqb_product_base
+          git clone https://github.com/istqborg/istqb_product_base.git /opt/istqb_product_base
+          cd /opt/istqb_product_base
+          git checkout ${{ inputs.base-version || github.sha }}
+          pip install -r requirements.txt --break-system-packages
+      - name: Compile Markdown documents
+        run: istqb-template compile-tex-to-markdown md/
+      - name: Upload Markdown documents
+        uses: actions/upload-artifact@v4
+        with:
+          name: MD
+          path: md/
   prerelease:
     name: Create a prerelease
     if: github.ref == 'refs/heads/main' && inputs.skip-prerelease == false

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -254,6 +254,7 @@ jobs:
       - produce-html
       - produce-ebooks
       - produce-docx
+      - produce-md
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -240,7 +240,7 @@ jobs:
           git checkout ${{ inputs.base-version || github.sha }}
           pip install -r requirements.txt --break-system-packages
       - name: Compile Markdown documents
-        run: istqb-template compile-tex-to-markdown md/
+        run: istqb-template compile-tex-to-md md/
       - name: Upload Markdown documents
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ To typeset ISTQB documents on your computer, take the following steps:
    Compiled file "/mnt/syllabus.tex" to "ISTQB-CT-TEMP-Syllabus-v0.1-EN.pdf"
    ```
 
-   Besides typesetting documents to PDF with the `compile-tex-to-pdf` command, you can also convert them to HTML, EPUB, and DOCX, among other things. Here is how you would list the available commands in a terminal of a Linux system:
+   Besides typesetting documents to PDF with the `compile-tex-to-pdf` command, you can also convert them to HTML, EPUB, DOCX, and combined Markdown, among other things. Here is how you would list the available commands in a terminal of a Linux system:
    ``` sh
    $ docker run --rm -it ghcr.io/istqborg/istqb_product_base --help
    ```
    ```
    usage: template.py [-h]
-                   {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx} ...
+                   {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx,compile-tex-to-markdown} ...
 
    Process ISTQB documents written with the LaTeX+Markdown template
 
    positional arguments:
-     {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx}
+     {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx,compile-tex-to-markdown}
        find-files          Produce a newline-separated list of different types of files in this repository
        fixup-languages     Determine and add `babel-language` to language definitions if missing
        fixup-line-endings  Convert all text files to Unix-style line endings
@@ -68,6 +68,8 @@ To typeset ISTQB documents on your computer, take the following steps:
                            Compile all TeX files in this repository to EPUB
        compile-tex-to-docx
                            Compile all TeX files in this repository to DOCX
+       compile-tex-to-markdown
+                           Compile selected TeX files in this repository to combined Markdown
 
    options:
      -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ To typeset ISTQB documents on your computer, take the following steps:
    Compiled file "/mnt/syllabus.tex" to "ISTQB-CT-TEMP-Syllabus-v0.1-EN.pdf"
    ```
 
-   Besides typesetting documents to PDF with the `compile-tex-to-pdf` command, you can also convert them to HTML, EPUB, DOCX, and combined Markdown, among other things. Here is how you would list the available commands in a terminal of a Linux system:
+   Besides typesetting documents to PDF with the `compile-tex-to-pdf` command, you can also convert them to HTML, EPUB, DOCX, and combined MD file, among other things. Here is how you would list the available commands in a terminal of a Linux system:
    ``` sh
    $ docker run --rm -it ghcr.io/istqborg/istqb_product_base --help
    ```
    ```
    usage: template.py [-h]
-                   {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx,compile-tex-to-markdown} ...
+                   {find-files,fixup-languages,fixup-line-endings,validate-files,convert-eps-to-pdf,convert-xlsx-to-pdf,convert-md-questions-to-yaml,convert-yaml-questions-to-md,compile-tex-to-pdf,compile-tex-to-html,compile-tex-to-epub,compile-tex-to-docx,compile-tex-to-md} ...
 
    Process ISTQB documents written with the LaTeX+Markdown template
 
@@ -68,8 +68,8 @@ To typeset ISTQB documents on your computer, take the following steps:
                            Compile all TeX files in this repository to EPUB
        compile-tex-to-docx
                            Compile all TeX files in this repository to DOCX
-       compile-tex-to-markdown
-                           Compile selected TeX files in this repository to combined Markdown
+       compile-tex-to-md
+                           Compile selected TeX files in this repository to a combined MD file
 
    options:
      -h, --help            show this help message and exit

--- a/template.py
+++ b/template.py
@@ -117,6 +117,8 @@ PDFTEX_UNPRINTED_REFERENCES = (
     r'pdfTeX warning \(dest\): name\{cite\.[0-9]+@(?P<cite_key>[^}]*)\} has been referenced but does not exist, replaced by a fixed one'
 )
 PDFTEX_UNPRINTED_REFERENCES = re.compile(PDFTEX_UNPRINTED_REFERENCES.replace(' ', r'\s+'))
+MARKDOWN_HEADING_REGEXP = re.compile(r'^(?P<hashes>#{1,6})\s+(?P<title>.*?)(?P<attrs>\s+\{[^{}]*\})?\s*$')
+MARKDOWN_LIST_ITEM_REGEXP = re.compile(r'^(?P<indent>\s*)(?:[-*+]|\d+[.)])\s+(?P<text>.+?)\s*$')
 
 
 FileLocation = Tuple[Path, int]
@@ -1303,6 +1305,111 @@ def _get_markdown_output_name(input_path: Path) -> str:
     return f'{code}{suffix}.md'
 
 
+def _is_unnumbered_markdown_heading(attributes: Optional[str]) -> bool:
+    if not attributes:
+        return False
+    return '-}' in attributes or '.unnumbered' in attributes
+
+
+def _is_learning_objectives_heading(attributes: Optional[str]) -> bool:
+    return bool(attributes and '.learning-objectives' in attributes)
+
+
+def _title_has_number_prefix(title: str, number: str) -> bool:
+    number_prefix = re.escape(number)
+    return bool(re.match(rf'^{number_prefix}(?=\s|$|[–-])', title))
+
+
+def _rewrite_learning_objectives_block(lines: List[str], chapter_number: int) -> List[str]:
+    rewritten_lines = []
+    subchapter_number = 0
+    learning_objective_number = 0
+    top_level_indent: Optional[int] = None
+
+    for line in lines:
+        list_item_match = MARKDOWN_LIST_ITEM_REGEXP.fullmatch(line)
+        if list_item_match is None:
+            rewritten_lines.append(line)
+            continue
+
+        indent = list_item_match.group('indent')
+        text = list_item_match.group('text')
+        indent_length = len(indent)
+        if top_level_indent is None:
+            top_level_indent = indent_length
+
+        if indent_length == top_level_indent:
+            subchapter_number += 1
+            learning_objective_number = 0
+            rewritten_lines.append(f'- {chapter_number}.{subchapter_number} {text}')
+        else:
+            learning_objective_number += 1
+            rewritten_lines.append(f'   - {chapter_number}.{subchapter_number}.{learning_objective_number} {text}')
+
+    return rewritten_lines
+
+
+def _rewrite_syllabus_markdown(markdown_text: str) -> str:
+    lines = markdown_text.splitlines()
+    rewritten_lines = []
+
+    chapter_number = -1
+    subchapter_number = 0
+    subsubchapter_number = 0
+
+    line_number = 0
+    while line_number < len(lines):
+        line = lines[line_number]
+        heading_match = MARKDOWN_HEADING_REGEXP.fullmatch(line)
+        if heading_match is None:
+            rewritten_lines.append(line)
+            line_number += 1
+            continue
+
+        hashes = heading_match.group('hashes')
+        title = heading_match.group('title')
+        attributes = heading_match.group('attrs') or ''
+        level = len(hashes)
+
+        formatted_title = title
+        if level == 1:
+            subchapter_number = 0
+            subsubchapter_number = 0
+            if not _is_unnumbered_markdown_heading(attributes):
+                chapter_number += 1
+                heading_number = str(chapter_number)
+                if not _title_has_number_prefix(title, heading_number):
+                    formatted_title = f'{heading_number} {title}'
+        elif level == 2 and chapter_number >= 0 and not _is_unnumbered_markdown_heading(attributes):
+            subchapter_number += 1
+            subsubchapter_number = 0
+            heading_number = f'{chapter_number}.{subchapter_number}'
+            if not _title_has_number_prefix(title, heading_number):
+                formatted_title = f'{heading_number} {title}'
+        elif level == 3 and chapter_number >= 0 and subchapter_number > 0 and not _is_unnumbered_markdown_heading(attributes):
+            subsubchapter_number += 1
+            heading_number = f'{chapter_number}.{subchapter_number}.{subsubchapter_number}'
+            if not _title_has_number_prefix(title, heading_number):
+                formatted_title = f'{heading_number} {title}'
+
+        rewritten_lines.append(f'{hashes} {formatted_title}{attributes}')
+        line_number += 1
+
+        if not _is_learning_objectives_heading(attributes) or chapter_number < 0:
+            continue
+
+        learning_objectives_lines = []
+        while line_number < len(lines):
+            nested_line = lines[line_number]
+            if MARKDOWN_HEADING_REGEXP.fullmatch(nested_line):
+                break
+            learning_objectives_lines.append(nested_line)
+            line_number += 1
+        rewritten_lines.extend(_rewrite_learning_objectives_block(learning_objectives_lines, chapter_number))
+
+    return '\n'.join(rewritten_lines).rstrip() + '\n'
+
+
 def _compile_tex_file_to_markdown(input_path: Path, output_directory: Path) -> Optional[Path]:
     document_type = _get_markdown_document_type(input_path)
     if document_type is None:
@@ -1327,7 +1434,10 @@ def _compile_tex_file_to_markdown(input_path: Path, output_directory: Path) -> O
         for markdown_input_path in markdown_input_paths:
             with markdown_input_path.open('rt') as f:
                 markdown_texts.append(f.read().rstrip())
-    output_path.write_text('\n\n'.join(markdown_texts) + '\n')
+    markdown_text = '\n\n'.join(markdown_texts) + '\n'
+    if document_type == 'syllabus':
+        markdown_text = _rewrite_syllabus_markdown(markdown_text)
+    output_path.write_text(markdown_text)
     return output_path
 
 

--- a/template.py
+++ b/template.py
@@ -63,6 +63,7 @@ BUILTIN_IDENTIFIERS = {'section:references', 'section:further-reading'}
 
 MARKDOWNINPUT_REGEXP = re.compile(r'\\markdownInput(\[.*?\])?{(?P<filename>.*?)}', re.DOTALL)
 ADDBIBRESOURCE_REGEXP = re.compile(r'\\addbibresource{(?P<filename>.*?)}', re.DOTALL)
+DOCUMENT_BODY_REGEXP = re.compile(r'^\s*%\s*Document (Text|Content)\s*$', re.MULTILINE)
 
 ATTRIBUTES_REGEXPS = {
     'section': re.compile(
@@ -937,6 +938,16 @@ def _read_md_questions(input_files: Iterable[Path]) -> Iterable[Tuple[int, Dict]
             question_number += 1
 
 
+def _get_sample_exam_markdown_paths(input_path: Path) -> List[Path]:
+    _convert_yaml_questions_to_md()
+    question_yaml_input_paths = [
+        nested_path
+        for nested_path in _get_flat_references_from_tex_files(tex_input_paths=[input_path], include_sources=False)
+        if QUESTIONS_YAML_REGEXP.fullmatch(nested_path.name)
+    ]
+    return [question_yaml_input_path.with_suffix('.md') for question_yaml_input_path in question_yaml_input_paths]
+
+
 def _cluster_files(input_paths: Iterable[Path]) -> Iterable[Tuple[Path, List[Path]]]:
     clusters = defaultdict(lambda: list())
     for input_path in input_paths:
@@ -1078,6 +1089,15 @@ def _get_metadata_path(input_path: Path, action: str) -> Optional[Path]:
     return metadata_path
 
 
+def _get_metadata_yaml(input_path: Path, action: str) -> Optional[Dict[str, Any]]:
+    metadata_path = _get_metadata_path(input_path, action)
+    if metadata_path is None:
+        return None
+    with metadata_path.open('rt') as f:
+        metadata_yaml_text = f.read()
+    return yaml.safe_load(metadata_yaml_text)
+
+
 def _should_compile_tex_file_to_pdf(input_path: Path) -> bool:
     if (input_path.parent / input_path.stem / 'NO_PDF').exists():
         return False
@@ -1205,6 +1225,110 @@ def _get_project_name(input_path: Path) -> str:
     language = metadata_yaml.get('language', 'en').upper().strip()
     project_name = f'{organization}-{code}-{document_type}-{version}-{language}'
     return project_name
+
+
+def _get_markdown_document_type(input_path: Path) -> Optional[str]:
+    if _is_sample_exam_questions(input_path):
+        return 'sample exam'
+    metadata_yaml = _get_metadata_yaml(input_path, 'determine whether it should be compiled to Markdown; will not compile')
+    if metadata_yaml is None:
+        return None
+    raw_document_type = str(metadata_yaml.get('type', '')).strip().lower()
+    normalized_document_types = {
+        'syllabus': 'syllabus',
+        'sylabus': 'syllabus',
+        'accreditation guidelines': 'accreditation guidelines',
+    }
+    return normalized_document_types.get(raw_document_type)
+
+
+def _get_document_body_markdown_paths(input_path: Path) -> List[Path]:
+    lines = input_path.read_text().splitlines()
+    in_document_body = False
+    paths: List[Path] = []
+    stop_markers = (
+        '% Appendices',
+        '% Bibliography',
+        '% Closing sections',
+        '% List of Tables',
+        '% List of Figures',
+        '% Index',
+    )
+    for line in lines:
+        stripped = line.strip()
+        if not in_document_body:
+            if DOCUMENT_BODY_REGEXP.fullmatch(stripped):
+                in_document_body = True
+            continue
+        if any(stripped.startswith(marker) for marker in stop_markers):
+            break
+        match = MARKDOWNINPUT_REGEXP.search(stripped)
+        if not match:
+            continue
+        referenced_path = Path(match.group('filename'))
+        if referenced_path.suffix.lower() != '.md':
+            continue
+        if not referenced_path.is_absolute():
+            referenced_path = (input_path.parent / referenced_path).resolve()
+        paths.append(referenced_path)
+    return paths
+
+
+def _get_markdown_output_name(input_path: Path) -> str:
+    metadata_yaml = _get_metadata_yaml(input_path, 'determine the Markdown output name')
+    if metadata_yaml is None:
+        return f'{input_path.stem}.md'
+    document_type = _get_markdown_document_type(input_path)
+    if document_type is None:
+        return f'{input_path.stem}.md'
+    code = str(metadata_yaml.get('code', input_path.stem)).strip().lower()
+    language = str(metadata_yaml.get('language', 'en')).strip().lower()
+    suffix_by_document_type = {
+        'syllabus': '-syllabus',
+        'accreditation guidelines': '-accreditation-guidelines',
+        'sample exam': '-sample-exam',
+    }
+    suffix = suffix_by_document_type[document_type]
+    if document_type == 'sample exam':
+        type_text = str(metadata_yaml.get('type', '')).strip().lower()
+        variant_match = re.fullmatch(r'sample exam(?:\s+(.*))?', type_text)
+        if variant_match is not None:
+            variant = variant_match.group(1)
+            if variant:
+                variant_slug = re.sub(r'[^a-z0-9]+', '-', variant).strip('-')
+                if variant_slug:
+                    suffix = f'{suffix}-{variant_slug}'
+    if language and language != 'en':
+        suffix = f'{suffix}-{language}'
+    return f'{code}{suffix}.md'
+
+
+def _compile_tex_file_to_markdown(input_path: Path, output_directory: Path) -> Optional[Path]:
+    document_type = _get_markdown_document_type(input_path)
+    if document_type is None:
+        return None
+    output_path = output_directory / _get_markdown_output_name(input_path)
+    if document_type == 'sample exam':
+        markdown_input_paths = _get_sample_exam_markdown_paths(input_path)
+        if not markdown_input_paths:
+            return None
+        if len(markdown_input_paths) == 1:
+            output_path.write_text(markdown_input_paths[0].read_text())
+            return output_path
+        markdown_texts = []
+        for markdown_input_path in markdown_input_paths:
+            with markdown_input_path.open('rt') as f:
+                markdown_texts.append(f.read().rstrip())
+    else:
+        markdown_input_paths = _get_document_body_markdown_paths(input_path)
+        if not markdown_input_paths:
+            return None
+        markdown_texts = []
+        for markdown_input_path in markdown_input_paths:
+            with markdown_input_path.open('rt') as f:
+                markdown_texts.append(f.read().rstrip())
+    output_path.write_text('\n\n'.join(markdown_texts) + '\n')
+    return output_path
 
 
 def _validate_log_file(input_path: Path) -> None:
@@ -1407,6 +1531,11 @@ def _compile_tex_files_to_docx(output_directory: Path, input_paths: Optional[Ite
     _compile_tex_files(_compile_tex_file_to_docx, output_directory, input_paths=input_paths)
 
 
+def _compile_tex_files_to_markdown(output_directory: Path, input_paths: Optional[Iterable[Path]]) -> None:
+    output_directory.mkdir(parents=True, exist_ok=True)
+    _compile_tex_files(_compile_tex_file_to_markdown, output_directory, input_paths=input_paths)
+
+
 def find_files(args: Namespace) -> None:
     file_types = [args.filetype]
     tex_input_paths = [Path(vars(args)['from'])] if vars(args)['from'] is not None else None
@@ -1461,6 +1590,11 @@ def compile_tex_files_to_epub(args: Namespace) -> None:
 def compile_tex_files_to_docx(args: Namespace) -> None:
     input_paths = sorted(map(Path, args.filenames)) if args.filenames else None
     _compile_tex_files_to_docx(Path(args.outputdir), input_paths)
+
+
+def compile_tex_files_to_markdown(args: Namespace) -> None:
+    input_paths = sorted(map(Path, args.filenames)) if args.filenames else None
+    _compile_tex_files_to_markdown(Path(args.outputdir), input_paths)
 
 
 def main():
@@ -1557,6 +1691,14 @@ def main():
     parser_compile_tex_files_to_docx.add_argument('outputdir')
     parser_compile_tex_files_to_docx.add_argument('filenames', nargs='*')
     parser_compile_tex_files_to_docx.set_defaults(func=compile_tex_files_to_docx)
+
+    parser_compile_tex_files_to_markdown = subparsers.add_parser(
+        'compile-tex-to-markdown',
+        help='Compile selected TeX files in this repository to combined Markdown',
+    )
+    parser_compile_tex_files_to_markdown.add_argument('outputdir')
+    parser_compile_tex_files_to_markdown.add_argument('filenames', nargs='*')
+    parser_compile_tex_files_to_markdown.set_defaults(func=compile_tex_files_to_markdown)
 
     args = parser.parse_args()
     if 'func' not in args:

--- a/template.py
+++ b/template.py
@@ -379,7 +379,8 @@ def _get_line_number_from_file_location(location: FileLocation) -> int:
 
 
 @lru_cache(maxsize=None)
-def _get_references_from_tex_file(tex_input_path: Path, include_sources: bool = True, include_appendices: bool = True) -> List[Tuple[FileLocation, Path, Iterable[Path]]]:
+def _get_references_from_tex_file(tex_input_path: Path, include_sources: bool = True,
+                                  include_appendices: bool = True) -> List[Tuple[FileLocation, Path, Iterable[Path]]]:
     results = []
     with tex_input_path.open('rt') as f:
         text = f.read()
@@ -1386,6 +1387,7 @@ def _get_markdown_output_name(input_path: Path) -> str:
         )
     output_name = f'{output_stem}.md'
     return output_name
+
 
 def _is_unnumbered_markdown_heading(attributes: Optional[str]) -> bool:
     if not attributes:

--- a/template.py
+++ b/template.py
@@ -1104,12 +1104,9 @@ def _should_compile_tex_file_to_pdf(input_path: Path) -> bool:
     if (input_path.parent / input_path.stem / 'NO_PDF').exists():
         return False
 
-    metadata_path = _get_metadata_path(input_path, 'determine whether it should be compiled to PDF; will compile')
-    if metadata_path is None:
+    metadata_yaml = _get_metadata_yaml(input_path, 'determine whether it should be compiled to PDF; will compile')
+    if metadata_yaml is None:
         return True
-    with metadata_path.open('rt') as f:
-        metadata_yaml_text = f.read()
-    metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'pdf-output' in metadata_yaml:
         pdf_output = bool(metadata_yaml['pdf-output'])
@@ -1126,13 +1123,9 @@ def _should_compile_tex_file_to_html(input_path: Path) -> bool:
     if (input_path.parent / input_path.stem / 'NO_HTML').exists():
         return False
 
-    metadata_path = _get_metadata_path(input_path, 'determine whether it should be compiled to HTML; will not compile')
-    if metadata_path is None:
+    metadata_yaml = _get_metadata_yaml(input_path, 'determine whether it should be compiled to HTML; will not compile')
+    if metadata_yaml is None:
         return False
-
-    with metadata_path.open('rt') as f:
-        metadata_yaml_text = f.read()
-    metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'html-output' in metadata_yaml:
         html_output = bool(metadata_yaml['html-output'])
@@ -1150,13 +1143,9 @@ def _should_compile_tex_file_to_epub(input_path: Path) -> bool:
     if (input_path.parent / input_path.stem / 'NO_HTML').exists():
         return False
 
-    metadata_path = _get_metadata_path(input_path, 'determine whether it should be compiled to EPUB; will not compile')
-    if metadata_path is None:
+    metadata_yaml = _get_metadata_yaml(input_path, 'determine whether it should be compiled to EPUB; will not compile')
+    if metadata_yaml is None:
         return False
-
-    with metadata_path.open('rt') as f:
-        metadata_yaml_text = f.read()
-    metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'epub-output' in metadata_yaml:
         epub_output = bool(metadata_yaml['epub-output'])
@@ -1178,13 +1167,9 @@ def _should_compile_tex_file_to_docx(input_path: Path) -> bool:
     if _is_sample_exam_answers(input_path):
         return False
 
-    metadata_path = _get_metadata_path(input_path, 'determine whether it should be compiled to DOCX; will not compile')
-    if metadata_path is None:
+    metadata_yaml = _get_metadata_yaml(input_path, 'determine whether it should be compiled to DOCX; will not compile')
+    if metadata_yaml is None:
         return False
-
-    with metadata_path.open('rt') as f:
-        metadata_yaml_text = f.read()
-    metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     if 'docx-output' in metadata_yaml:
         docx_output = bool(metadata_yaml['docx-output'])
@@ -1208,13 +1193,9 @@ def _get_project_name(input_path: Path) -> str:
     basename = input_path.stem
     if input_path == EXAMPLE_DOCUMENT:
         return basename
-    metadata_path = _get_metadata_path(input_path, f'determine the project name; will use "{basename}"')
-    if metadata_path is None:
+    metadata_yaml = _get_metadata_yaml(input_path, f'determine the project name; will use "{basename}"')
+    if metadata_yaml is None:
         return basename
-
-    with metadata_path.open('rt') as f:
-        metadata_yaml_text = f.read()
-    metadata_yaml = yaml.safe_load(metadata_yaml_text)
 
     organization = metadata_yaml.get('organization', 'ISTQB®').replace('®', '').strip()
     code = metadata_yaml.get('code', 'CODE').strip()

--- a/template.py
+++ b/template.py
@@ -61,9 +61,9 @@ PANDOC_EXTENSIONS = ['bracketed_spans', 'fancy_lists', 'pipe_tables', 'raw_attri
 
 BUILTIN_IDENTIFIERS = {'section:references', 'section:further-reading'}
 
+ISTQB_APPENDICES_REGEXP = re.compile(r'\\begin{istqbappendices}.*', re.DOTALL)
 MARKDOWNINPUT_REGEXP = re.compile(r'\\markdownInput(\[.*?\])?{(?P<filename>.*?)}', re.DOTALL)
 ADDBIBRESOURCE_REGEXP = re.compile(r'\\addbibresource{(?P<filename>.*?)}', re.DOTALL)
-DOCUMENT_BODY_REGEXP = re.compile(r'^\s*%\s*Document (Text|Content)\s*$', re.MULTILINE)
 
 ATTRIBUTES_REGEXPS = {
     'section': re.compile(
@@ -94,11 +94,12 @@ MARKDOWN_REGEXP = re.compile(r'\.(md|mdown|markdown)$', flags=re.IGNORECASE)
 YAML_REGEXP = re.compile(r'\.ya?ml$', flags=re.IGNORECASE)
 TEMPLATE_REGEXP = re.compile(r'\.(sty|cls|lua)$', flags=re.IGNORECASE)
 
-METADATA_REGEXP = re.compile(r'metadata.*\.ya?ml', flags=re.IGNORECASE)
-QUESTIONS_YAML_REGEXP = re.compile(r'questions.*\.ya?ml', flags=re.IGNORECASE)
-QUESTIONS_MARKDOWN_REGEXP = re.compile(r'.*question.*\.(md|mdown|markdown)', flags=re.IGNORECASE)
-LANGUAGES_REGEXP = re.compile(r'..\.ya?ml', flags=re.IGNORECASE)
-TRACEABILITY_MATRIX_REGEXP = re.compile(r'traceability-matrix\.ya?ml$', flags=re.IGNORECASE)
+METADATA_REGEXP = re.compile(r'metadata.*%s' % YAML_REGEXP.pattern, flags=re.IGNORECASE)
+QUESTIONS_YAML_REGEXP = re.compile(r'questions.*%s' % YAML_REGEXP.pattern, flags=re.IGNORECASE)
+QUESTIONS_MARKDOWN_REGEXP = re.compile(r'.*question.*%s' % MARKDOWN_REGEXP.pattern, flags=re.IGNORECASE)
+BOILERPLATE_MARKDOWN_REGEXP = re.compile(r'.*(copyright|revisions).*%s' % MARKDOWN_REGEXP.pattern, flags=re.IGNORECASE)
+LANGUAGES_REGEXP = re.compile(r'..%s' % YAML_REGEXP.pattern, flags=re.IGNORECASE)
+TRACEABILITY_MATRIX_REGEXP = re.compile(r'traceability-matrix%s' % YAML_REGEXP.pattern, flags=re.IGNORECASE)
 
 QUESTIONS_METADATA_REGEXP = re.compile(r'\s{0,3}#\s*metadata\s*', flags=re.IGNORECASE)
 QUESTIONS_QUESTION_REGEXP = re.compile(r'\s{0,3}##\s*question\s*', flags=re.IGNORECASE)
@@ -378,10 +379,12 @@ def _get_line_number_from_file_location(location: FileLocation) -> int:
 
 
 @lru_cache(maxsize=None)
-def _get_references_from_tex_file(tex_input_path: Path, include_sources: bool = True) -> List[Tuple[FileLocation, Path, Iterable[Path]]]:
+def _get_references_from_tex_file(tex_input_path: Path, include_sources: bool = True, include_appendices: bool = True) -> List[Tuple[FileLocation, Path, Iterable[Path]]]:
     results = []
     with tex_input_path.open('rt') as f:
         text = f.read()
+        if not include_appendices:
+            text = ISTQB_APPENDICES_REGEXP.sub('', text)
         for pattern in [MARKDOWNINPUT_REGEXP, ADDBIBRESOURCE_REGEXP]:
             for match in pattern.finditer(text):
                 # Yield directly referenced paths.
@@ -412,6 +415,10 @@ def _get_references_from_tex_files(tex_input_paths: Iterable[Path], *args, **kwa
 
 def _flatten_references(references: Iterable[Tuple[FileLocation, Path, Iterable[Path]]]) -> Iterable[Path]:
     return chain(*[paths for *_, paths in references])
+
+
+def _get_flat_references_from_tex_file(tex_input_path: Path, *args, **kwargs) -> Iterable[Path]:
+    return _flatten_references(_get_references_from_tex_file(tex_input_path, *args, **kwargs))
 
 
 def _get_flat_references_from_tex_files(tex_input_paths: Iterable[Path], *args, **kwargs) -> Iterable[Path]:
@@ -944,7 +951,7 @@ def _get_sample_exam_markdown_paths(input_path: Path) -> List[Path]:
     _convert_yaml_questions_to_md()
     question_yaml_input_paths = [
         nested_path
-        for nested_path in _get_flat_references_from_tex_files(tex_input_paths=[input_path], include_sources=False)
+        for nested_path in _get_flat_references_from_tex_file(input_path, include_sources=False)
         if QUESTIONS_YAML_REGEXP.fullmatch(nested_path.name)
     ]
     return [question_yaml_input_path.with_suffix('.md') for question_yaml_input_path in question_yaml_input_paths]
@@ -1189,6 +1196,49 @@ def _is_sample_exam_answers(input_path: Path) -> bool:
     return 'answers' in input_path.name
 
 
+@lru_cache(maxsize=None)
+def _get_document_type(input_path: Path) -> Optional[str]:
+    metadata_yaml = _get_metadata_yaml(input_path, 'determine the document type')
+    if metadata_yaml is None:
+        return False
+
+    document_type = str(metadata_yaml.get('type', '')).strip().lower()
+    return document_type
+
+
+def _is_syllabus(input_path: Path) -> bool:
+    if 'syllabus' in input_path.name:
+        return True
+
+    document_type = _get_document_type(input_path)
+    if document_type is None:
+        return False
+    return document_type in {'syllabus', 'sylabus'}
+
+
+def _is_accreditation_guidelines(input_path: Path) -> bool:
+    if 'accreditation-guidelines' in input_path.name:
+        return True
+
+    document_type = _get_document_type(input_path)
+    if document_type is None:
+        return False
+    return document_type == 'accreditation guidelines'
+
+
+def _should_compile_tex_file_to_md(input_path: Path) -> bool:
+    if _is_sample_exam_questions(input_path):
+        return True
+
+    if _is_syllabus(input_path):
+        return True
+
+    if _is_accreditation_guidelines(input_path):
+        return True
+
+    return False
+
+
 def _get_project_name(input_path: Path) -> str:
     basename = input_path.stem
     if input_path == EXAMPLE_DOCUMENT:
@@ -1210,81 +1260,132 @@ def _get_project_name(input_path: Path) -> str:
     return project_name
 
 
-def _get_markdown_document_type(input_path: Path) -> Optional[str]:
-    if _is_sample_exam_questions(input_path):
-        return 'sample exam'
-    metadata_yaml = _get_metadata_yaml(input_path, 'determine whether it should be compiled to Markdown; will not compile')
-    if metadata_yaml is None:
-        return None
-    raw_document_type = str(metadata_yaml.get('type', '')).strip().lower()
-    normalized_document_types = {
-        'syllabus': 'syllabus',
-        'sylabus': 'syllabus',
-        'accreditation guidelines': 'accreditation guidelines',
-    }
-    return normalized_document_types.get(raw_document_type)
+def _validate_log_file(input_path: Path) -> None:
+    with input_path.open('rb') as f:
+        log_text = f.read().decode('utf8', 'ignore')
+    unprinted_references = [
+        f'"{match.group("cite_key")}"'
+        for match
+        in PDFTEX_UNPRINTED_REFERENCES.finditer(log_text)
+    ]
+    if unprinted_references:
+        raise ValueError(
+            f'The BIB entry for the citation{"s" if len(unprinted_references) > 1 else ""} {", ".join(unprinted_references)} '
+            'matches no known reference type (Standards, ISTQB Documents, Books, Articles, Web Pages, and Glossary References). '
+            'To see how the the BIB entries should be formatted, see Section 1.14 (References) of the example document '
+            '<https://github.com/istqborg/istqb_product_base/releases/download/latest/example-document.pdf>'
+        )
 
 
-def _get_document_body_markdown_paths(input_path: Path) -> List[Path]:
-    lines = input_path.read_text().splitlines()
-    in_document_body = False
-    paths: List[Path] = []
-    stop_markers = (
-        '% Appendices',
-        '% Bibliography',
-        '% Closing sections',
-        '% List of Tables',
-        '% List of Figures',
-        '% Index',
-    )
-    for line in lines:
-        stripped = line.strip()
-        if not in_document_body:
-            if DOCUMENT_BODY_REGEXP.fullmatch(stripped):
-                in_document_body = True
-            continue
-        if any(stripped.startswith(marker) for marker in stop_markers):
-            break
-        match = MARKDOWNINPUT_REGEXP.search(stripped)
-        if not match:
-            continue
-        referenced_path = Path(match.group('filename'))
-        if referenced_path.suffix.lower() != '.md':
-            continue
-        if not referenced_path.is_absolute():
-            referenced_path = (input_path.parent / referenced_path).resolve()
-        paths.append(referenced_path)
-    return paths
+def _compile_tex_file_to_pdf(input_path: Path, previous_continuous: bool) -> Optional[Path]:
+    if not _should_compile_tex_file_to_pdf(input_path):
+        return
+    if previous_continuous:
+        _run_command('latexmk', '-pvc', '-r', f'{LATEXMKRC}', f'{input_path}', timeout=None)
+    else:
+        _run_command('latexmk', '-r', f'{LATEXMKRC}', f'{input_path}', timeout=600)
+        _validate_log_file(input_path.with_suffix('.log'))
+    project_name = _get_project_name(input_path)
+    output_path = Path(f'{project_name}.pdf')
+    input_path.with_suffix('.pdf').rename(output_path)
+    return output_path
+
+
+def _compile_tex_file_to_html(input_path: Path, output_directory: Path) -> Optional[Path]:
+    if not _should_compile_tex_file_to_html(input_path):
+        return
+    project_name = _get_project_name(input_path)
+    output_path = output_directory / project_name / input_path.with_suffix('.html').name
+    _run_command('make4ht', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_path.parent}', f'{input_path}', timeout=600)
+    return output_path
+
+
+def _compile_tex_file_to_epub(input_path: Path, output_directory: Path) -> Optional[Path]:
+    if not _should_compile_tex_file_to_epub(input_path):
+        return
+
+    output_directory = output_directory.resolve()
+    build_directory = output_directory / 'build' / input_path.stem
+
+    def prune_output_directory(parent_directory: str, filenames: List[str]) -> List[str]:
+        parent_directory = Path(parent_directory).resolve()
+        if parent_directory == output_directory.parent:
+            return [output_directory.name]
+        return []
+
+    shutil.copytree(input_path.parent, build_directory, ignore=prune_output_directory)
+
+    with _change_directory(build_directory):
+        _run_command(
+            'tex4ebook', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_directory}', input_path.name,
+            timeout=600,
+        )
+
+    shutil.rmtree(build_directory)
+
+    project_name = _get_project_name(input_path)
+    output_path = output_directory / f'{project_name}.epub'
+    (output_directory / input_path.with_suffix('.epub').name).rename(output_path)
+    return output_path
+
+
+def _compile_tex_file_to_docx(input_path: Path, output_directory: Path) -> Optional[Path]:
+    if not _should_compile_tex_file_to_docx(input_path):
+        return
+
+    # Collect files referenced from the TeX file.
+    markdown_texts = []
+    for nested_path in _get_flat_references_from_tex_file(input_path, include_sources=False):
+        if MARKDOWN_REGEXP.search(nested_path.name):
+            with nested_path.open('rt') as f:
+                markdown_text = f.read()
+                markdown_texts.append(markdown_text)
+        elif YAML_REGEXP.search(nested_path.name):
+            if QUESTIONS_YAML_REGEXP.fullmatch(nested_path.name):
+                with nested_path.with_suffix('.md').open('rt') as f:
+                    markdown_text = f.read()
+                    markdown_texts.append(markdown_text)
+            else:
+                with nested_path.open('rt') as f:
+                    markdown_text = f'``` yml\n{f.read()}\n```'
+                    markdown_texts.append(markdown_text)
+        elif BIB_REGEXP.search(nested_path.name):
+            with nested_path.open('rt') as f:
+                markdown_text = f'``` bib\n{f.read()}\n```'
+                markdown_texts.append(markdown_text)
+
+    # Convert the collected files to DOCX.
+    markdown_text = '\n\n'.join(markdown_texts)
+    pandoc_from_format = '+'.join([PANDOC_INPUT_FORMAT, *PANDOC_EXTENSIONS])
+    project_name = _get_project_name(input_path)
+    output_path = output_directory / f'{project_name}.docx'
+    with NamedTemporaryFile('wt', delete=False) as f:
+        print(markdown_text, file=f)
+        f.close()
+        _run_command('pandoc', '-f', f'{pandoc_from_format}', '-i', f'{f.name}', '-o', f'{output_path}')
+        os.unlink(f.name)
+
+    return output_path
 
 
 def _get_markdown_output_name(input_path: Path) -> str:
     metadata_yaml = _get_metadata_yaml(input_path, 'determine the Markdown output name')
     if metadata_yaml is None:
-        return f'{input_path.stem}.md'
-    document_type = _get_markdown_document_type(input_path)
-    if document_type is None:
-        return f'{input_path.stem}.md'
-    code = str(metadata_yaml.get('code', input_path.stem)).strip().lower()
-    language = str(metadata_yaml.get('language', 'en')).strip().lower()
-    suffix_by_document_type = {
-        'syllabus': '-syllabus',
-        'accreditation guidelines': '-accreditation-guidelines',
-        'sample exam': '-sample-exam',
-    }
-    suffix = suffix_by_document_type[document_type]
-    if document_type == 'sample exam':
-        type_text = str(metadata_yaml.get('type', '')).strip().lower()
-        variant_match = re.fullmatch(r'sample exam(?:\s+(.*))?', type_text)
-        if variant_match is not None:
-            variant = variant_match.group(1)
-            if variant:
-                variant_slug = re.sub(r'[^a-z0-9]+', '-', variant).strip('-')
-                if variant_slug:
-                    suffix = f'{suffix}-{variant_slug}'
-    if language and language != 'en':
-        suffix = f'{suffix}-{language}'
-    return f'{code}{suffix}.md'
-
+        output_stem = input_path.stem
+    else:
+        code = str(metadata_yaml.get('code', input_path.stem))
+        document_type = str(metadata_yaml.get('type', ''))
+        language = str(metadata_yaml.get('language', 'en'))
+        output_stem_buffer = [code, document_type]
+        if language and language != 'en':
+            output_stem_buffer.append(language)
+        output_stem = '-'.join(
+            re.sub(r'\s+', '-', name_segment.strip().lower())
+            for name_segment
+            in output_stem_buffer
+        )
+    output_name = f'{output_stem}.md'
+    return output_name
 
 def _is_unnumbered_markdown_heading(attributes: Optional[str]) -> bool:
     if not attributes:
@@ -1392,141 +1493,27 @@ def _rewrite_syllabus_markdown(markdown_text: str) -> str:
 
 
 def _compile_tex_file_to_md(input_path: Path, output_directory: Path) -> Optional[Path]:
-    document_type = _get_markdown_document_type(input_path)
-    if document_type is None:
-        return None
-    output_path = output_directory / _get_markdown_output_name(input_path)
-    if document_type == 'sample exam':
-        markdown_input_paths = _get_sample_exam_markdown_paths(input_path)
-        if not markdown_input_paths:
-            return None
-        if len(markdown_input_paths) == 1:
-            output_path.write_text(markdown_input_paths[0].read_text())
-            return output_path
-        markdown_texts = []
-        for markdown_input_path in markdown_input_paths:
-            with markdown_input_path.open('rt') as f:
-                markdown_texts.append(f.read().rstrip())
-    else:
-        markdown_input_paths = _get_document_body_markdown_paths(input_path)
-        if not markdown_input_paths:
-            return None
-        markdown_texts = []
-        for markdown_input_path in markdown_input_paths:
-            with markdown_input_path.open('rt') as f:
-                markdown_texts.append(f.read().rstrip())
-    markdown_text = '\n\n'.join(markdown_texts) + '\n'
-    if document_type == 'syllabus':
-        markdown_text = _rewrite_syllabus_markdown(markdown_text)
-    output_path.write_text(markdown_text)
-    return output_path
-
-
-def _validate_log_file(input_path: Path) -> None:
-    with input_path.open('rb') as f:
-        log_text = f.read().decode('utf8', 'ignore')
-    unprinted_references = [
-        f'"{match.group("cite_key")}"'
-        for match
-        in PDFTEX_UNPRINTED_REFERENCES.finditer(log_text)
-    ]
-    if unprinted_references:
-        raise ValueError(
-            f'The BIB entry for the citation{"s" if len(unprinted_references) > 1 else ""} {", ".join(unprinted_references)} '
-            'matches no known reference type (Standards, ISTQB Documents, Books, Articles, Web Pages, and Glossary References). '
-            'To see how the the BIB entries should be formatted, see Section 1.14 (References) of the example document '
-            '<https://github.com/istqborg/istqb_product_base/releases/download/latest/example-document.pdf>'
-        )
-
-
-def _compile_tex_file_to_pdf(input_path: Path, previous_continuous: bool) -> Optional[Path]:
-    if not _should_compile_tex_file_to_pdf(input_path):
-        return
-    if previous_continuous:
-        _run_command('latexmk', '-pvc', '-r', f'{LATEXMKRC}', f'{input_path}', timeout=None)
-    else:
-        _run_command('latexmk', '-r', f'{LATEXMKRC}', f'{input_path}', timeout=600)
-        _validate_log_file(input_path.with_suffix('.log'))
-    project_name = _get_project_name(input_path)
-    output_path = Path(f'{project_name}.pdf')
-    input_path.with_suffix('.pdf').rename(output_path)
-    return output_path
-
-
-def _compile_tex_file_to_html(input_path: Path, output_directory: Path) -> Optional[Path]:
-    if not _should_compile_tex_file_to_html(input_path):
-        return
-    project_name = _get_project_name(input_path)
-    output_path = output_directory / project_name / input_path.with_suffix('.html').name
-    _run_command('make4ht', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_path.parent}', f'{input_path}', timeout=600)
-    return output_path
-
-
-def _compile_tex_file_to_epub(input_path: Path, output_directory: Path) -> Optional[Path]:
-    if not _should_compile_tex_file_to_epub(input_path):
-        return
-
-    output_directory = output_directory.resolve()
-    build_directory = output_directory / 'build' / input_path.stem
-
-    def prune_output_directory(parent_directory: str, filenames: List[str]) -> List[str]:
-        parent_directory = Path(parent_directory).resolve()
-        if parent_directory == output_directory.parent:
-            return [output_directory.name]
-        return []
-
-    shutil.copytree(input_path.parent, build_directory, ignore=prune_output_directory)
-
-    with _change_directory(build_directory):
-        _run_command(
-            'tex4ebook', '-s', '-c', f'{ISTQB_CFG}', '-e', f'{ISTQB_MK4}', '-d', f'{output_directory}', input_path.name,
-            timeout=600,
-        )
-
-    shutil.rmtree(build_directory)
-
-    project_name = _get_project_name(input_path)
-    output_path = output_directory / f'{project_name}.epub'
-    (output_directory / input_path.with_suffix('.epub').name).rename(output_path)
-    return output_path
-
-
-def _compile_tex_file_to_docx(input_path: Path, output_directory: Path) -> Optional[Path]:
-    if not _should_compile_tex_file_to_docx(input_path):
+    if not _should_compile_tex_file_to_md(input_path):
         return
 
     # Collect files referenced from the TeX file.
     markdown_texts = []
-    for nested_path in _get_flat_references_from_tex_files(tex_input_paths=[input_path], include_sources=False):
+    for nested_path in _get_flat_references_from_tex_file(input_path, include_appendices=False):
+        if BOILERPLATE_MARKDOWN_REGEXP.search(nested_path.name):
+            continue
         if MARKDOWN_REGEXP.search(nested_path.name):
             with nested_path.open('rt') as f:
                 markdown_text = f.read()
                 markdown_texts.append(markdown_text)
-        elif YAML_REGEXP.search(nested_path.name):
-            if QUESTIONS_YAML_REGEXP.fullmatch(nested_path.name):
-                with nested_path.with_suffix('.md').open('rt') as f:
-                    markdown_text = f.read()
-                    markdown_texts.append(markdown_text)
-            else:
-                with nested_path.open('rt') as f:
-                    markdown_text = f'``` yml\n{f.read()}\n```'
-                    markdown_texts.append(markdown_text)
-        elif BIB_REGEXP.search(nested_path.name):
-            with nested_path.open('rt') as f:
-                markdown_text = f'``` bib\n{f.read()}\n```'
-                markdown_texts.append(markdown_text)
 
-    # Convert the collected files to DOCX.
-    markdown_text = '\n\n'.join(markdown_texts)
-    pandoc_from_format = '+'.join([PANDOC_INPUT_FORMAT, *PANDOC_EXTENSIONS])
-    project_name = _get_project_name(input_path)
-    output_path = output_directory / f'{project_name}.docx'
-    with NamedTemporaryFile('wt', delete=False) as f:
+    # Convert the collected files to MD.
+    markdown_text = '\n\n'.join(markdown_text.strip() for markdown_text in markdown_texts)
+    if _is_syllabus(input_path):
+        markdown_text = _rewrite_syllabus_markdown(markdown_text)
+    markdown_output_name = _get_markdown_output_name(input_path)
+    output_path = output_directory / markdown_output_name
+    with output_path.open('wt') as f:
         print(markdown_text, file=f)
-        f.close()
-        _run_command('pandoc', '-f', f'{pandoc_from_format}', '-i', f'{f.name}', '-o', f'{output_path}')
-        os.unlink(f.name)
-
     return output_path
 
 
@@ -1550,7 +1537,7 @@ def _should_compile_tex_file(input_path: Path) -> bool:
         return True
 
     changed_paths = set(_changed_paths())
-    referenced_paths = set(chain([input_path], _get_flat_references_from_tex_files([input_path])))
+    referenced_paths = set(chain([input_path], _get_flat_references_from_tex_file(input_path)))
     return bool(referenced_paths & changed_paths)
 
 

--- a/template.py
+++ b/template.py
@@ -1410,7 +1410,7 @@ def _rewrite_syllabus_markdown(markdown_text: str) -> str:
     return '\n'.join(rewritten_lines).rstrip() + '\n'
 
 
-def _compile_tex_file_to_markdown(input_path: Path, output_directory: Path) -> Optional[Path]:
+def _compile_tex_file_to_md(input_path: Path, output_directory: Path) -> Optional[Path]:
     document_type = _get_markdown_document_type(input_path)
     if document_type is None:
         return None
@@ -1641,9 +1641,9 @@ def _compile_tex_files_to_docx(output_directory: Path, input_paths: Optional[Ite
     _compile_tex_files(_compile_tex_file_to_docx, output_directory, input_paths=input_paths)
 
 
-def _compile_tex_files_to_markdown(output_directory: Path, input_paths: Optional[Iterable[Path]]) -> None:
+def _compile_tex_files_to_md(output_directory: Path, input_paths: Optional[Iterable[Path]]) -> None:
     output_directory.mkdir(parents=True, exist_ok=True)
-    _compile_tex_files(_compile_tex_file_to_markdown, output_directory, input_paths=input_paths)
+    _compile_tex_files(_compile_tex_file_to_md, output_directory, input_paths=input_paths)
 
 
 def find_files(args: Namespace) -> None:
@@ -1702,9 +1702,9 @@ def compile_tex_files_to_docx(args: Namespace) -> None:
     _compile_tex_files_to_docx(Path(args.outputdir), input_paths)
 
 
-def compile_tex_files_to_markdown(args: Namespace) -> None:
+def compile_tex_files_to_md(args: Namespace) -> None:
     input_paths = sorted(map(Path, args.filenames)) if args.filenames else None
-    _compile_tex_files_to_markdown(Path(args.outputdir), input_paths)
+    _compile_tex_files_to_md(Path(args.outputdir), input_paths)
 
 
 def main():
@@ -1802,13 +1802,13 @@ def main():
     parser_compile_tex_files_to_docx.add_argument('filenames', nargs='*')
     parser_compile_tex_files_to_docx.set_defaults(func=compile_tex_files_to_docx)
 
-    parser_compile_tex_files_to_markdown = subparsers.add_parser(
-        'compile-tex-to-markdown',
-        help='Compile selected TeX files in this repository to combined Markdown',
+    parser_compile_tex_files_to_md = subparsers.add_parser(
+        'compile-tex-to-md',
+        help='Compile selected TeX files in this repository to a combined MD file',
     )
-    parser_compile_tex_files_to_markdown.add_argument('outputdir')
-    parser_compile_tex_files_to_markdown.add_argument('filenames', nargs='*')
-    parser_compile_tex_files_to_markdown.set_defaults(func=compile_tex_files_to_markdown)
+    parser_compile_tex_files_to_md.add_argument('outputdir')
+    parser_compile_tex_files_to_md.add_argument('filenames', nargs='*')
+    parser_compile_tex_files_to_md.set_defaults(func=compile_tex_files_to_md)
 
     args = parser.parse_args()
     if 'func' not in args:

--- a/template.py
+++ b/template.py
@@ -1199,7 +1199,7 @@ def _is_sample_exam_answers(input_path: Path) -> bool:
 def _get_document_type(input_path: Path) -> Optional[str]:
     metadata_yaml = _get_metadata_yaml(input_path, 'determine the document type')
     if metadata_yaml is None:
-        return False
+        return None
 
     document_type = str(metadata_yaml.get('type', '')).strip().lower()
     return document_type

--- a/template.py
+++ b/template.py
@@ -1498,13 +1498,18 @@ def _compile_tex_file_to_md(input_path: Path, output_directory: Path) -> Optiona
 
     # Collect files referenced from the TeX file.
     markdown_texts = []
-    for nested_path in _get_flat_references_from_tex_file(input_path, include_appendices=False):
-        if BOILERPLATE_MARKDOWN_REGEXP.search(nested_path.name):
-            continue
+    for nested_path in _get_flat_references_from_tex_file(input_path, include_sources=False, include_appendices=False):
         if MARKDOWN_REGEXP.search(nested_path.name):
+            if BOILERPLATE_MARKDOWN_REGEXP.search(nested_path.name):
+                continue
             with nested_path.open('rt') as f:
                 markdown_text = f.read()
                 markdown_texts.append(markdown_text)
+        elif YAML_REGEXP.search(nested_path.name):
+            if QUESTIONS_YAML_REGEXP.fullmatch(nested_path.name):
+                with nested_path.with_suffix('.md').open('rt') as f:
+                    markdown_text = f.read()
+                    markdown_texts.append(markdown_text)
 
     # Convert the collected files to MD.
     markdown_text = '\n\n'.join(markdown_text.strip() for markdown_text in markdown_texts)

--- a/template.py
+++ b/template.py
@@ -397,7 +397,7 @@ def _get_references_from_tex_file(tex_input_path: Path, include_sources: bool = 
                 referenced_paths = [referenced_path]
                 # For YAML questions, yield also MD question source files.
                 if include_sources and QUESTIONS_YAML_REGEXP.fullmatch(referenced_path.name):
-                    for referenced_md_path in referenced_path.parent.iterdir():
+                    for referenced_md_path in sorted(referenced_path.parent.iterdir()):
                         if not referenced_md_path.is_file():
                             continue
                         if QUESTIONS_MARKDOWN_REGEXP.fullmatch(referenced_md_path.name):


### PR DESCRIPTION
This PR adds the following features:

- Add `compile-tex-to-md` action to `template.py`.

This PR builds on the branch `207-combined-md-files-from-ci` from @danopolan, following the review of https://github.com/istqborg/istqb_product_base/pull/211/commits/0b535691f1544f05a0e5dc4dda669e9856fe2bc9 and the discussion in https://github.com/istqborg/istqb_product_base/issues/207.

Compared to the original code from 0b535691f1544f05a0e5dc4dda669e9856fe2bc9, the code in this PR is simplified (see the review of https://github.com/istqborg/istqb_product_base/commit/0b535691f1544f05a0e5dc4dda669e9856fe2bc9) and doesn't include duplicate questions in the MD output for Sample Exam documents. I made no changes to the code introduced in the following commit https://github.com/istqborg/istqb_product_base/pull/211/commits/2594ed4476551be777395ad21f640035ffdcbf02, which adds a Markdown parser and appeared reasonably self-contained and robust against unexpected input.

I tested the output on CTAL-AT and CT-FT documents with no discernible differences except the lack of duplicate questions for the Sample Exam documents.

Closes https://github.com/istqborg/istqb_product_base/issues/207.